### PR TITLE
chore:Replace Jest with native test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [20, 18]
+        node: [24, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,15 +16,6 @@ module.exports = [
         module: 'readonly',
         require: 'readonly',
         exports: 'writable',
-        // Jest globals
-        describe: 'readonly',
-        test: 'readonly',
-        expect: 'readonly',
-        beforeEach: 'readonly',
-        afterEach: 'readonly',
-        beforeAll: 'readonly',
-        afterAll: 'readonly',
-        jest: 'readonly',
       },
     },
     rules: {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "npx jest --silent",
+    "test": "node --test",
     "lint": "npx eslint ."
   },
   "peerDependencies": {
     "@sap/cds": ">=7.6"
   },
   "devDependencies": {
-    "jest": "^29",
     "eslint": "^10.0.0"
   }
 }

--- a/test/lib/compile/asyncapiMetadata.test.js
+++ b/test/lib/compile/asyncapiMetadata.test.js
@@ -1,3 +1,5 @@
+const { describe, test, beforeEach } = require('node:test');
+const assert = require('node:assert');
 const toAsyncAPI = require('../../../lib/compile');
 const cds = require('@sap/cds');
 const { read } = cds.utils;
@@ -43,7 +45,7 @@ describe('asyncapi export: presets and annotations', () => {
         const csn = cds.compile.to.csn(inputCDS);
         const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'presets.json')));
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
     });
 
     test('Only annotations', async () => {
@@ -51,7 +53,7 @@ describe('asyncapi export: presets and annotations', () => {
         const csn = cds.compile.to.csn(inputCDS);
         const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'base.json')));
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
     });
 
     test('Only ODM annotations', async () => {
@@ -59,7 +61,7 @@ describe('asyncapi export: presets and annotations', () => {
         const csn = cds.compile.to.csn(inputCDS);
         const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'annotations.json')));
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
     });
 
     test('Presets and annotations precedence', async () => {
@@ -71,22 +73,22 @@ describe('asyncapi export: presets and annotations', () => {
         const csn = cds.compile.to.csn(inputCDS);
         const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'base.json')));
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI.components.messages["com.sap.base.MyName.v1"]["x-sap-event-spec-version"]).toEqual('1.0.0');
-        expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+        assert.strictEqual(generatedAsyncAPI.components.messages["com.sap.base.MyName.v1"]["x-sap-event-spec-version"], '1.0.0');
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
     });
 
     test('Error is thrown if no service is present', async () => {
         const inputCDS = await read(join(baseInputPath, 'invalid', 'serviceLess.cds'));
         const csn = cds.compile.to.csn(inputCDS);
-        expect(() => toAsyncAPI(csn)).toThrowError("There are no service definitions found in the given model(s).");
+        assert.throws(() => toAsyncAPI(csn), /There are no service definitions found in the given model\(s\)\./);
     });
 
     test('Check for default title and version if not provided in the input', async () => {
         const inputCDS = await read(join(baseInputPath, 'invalid', 'noTitle.cds'));
         const csn = cds.compile.to.csn(inputCDS);
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI).toHaveProperty('info.title', `Use @title: '...' on your CDS service to provide a meaningful title.`);
-        expect(generatedAsyncAPI).toHaveProperty('info.version', '1.0.0');
+        assert.strictEqual(generatedAsyncAPI.info.title, `Use @title: '...' on your CDS service to provide a meaningful title.`);
+        assert.strictEqual(generatedAsyncAPI.info.version, '1.0.0');
     });
 
     test('Test for application namespace', async () => {
@@ -94,14 +96,14 @@ describe('asyncapi export: presets and annotations', () => {
         cds.env.export.asyncapi = {};
         const csn = cds.compile.to.csn(inputCDS);
         const generatedAsyncAPI = toAsyncAPI(csn);
-        expect(generatedAsyncAPI).toHaveProperty('x-sap-application-namespace','customer.cap-js-asyncapi')
+        assert.strictEqual(generatedAsyncAPI['x-sap-application-namespace'], 'customer.cap-js-asyncapi');
     });
     test('Console warnings and errors are not used', async () => {
         const inputCDS = await read(join(baseInputPath, 'valid', 'presets.cds'));
         const csn = cds.compile.to.csn(inputCDS);
         const generatedAsyncAPI = toAsyncAPI(csn);
 
-        expect(generatedAsyncAPI).not.toHaveProperty('console.warn');
-        expect(generatedAsyncAPI).not.toHaveProperty('console.error');
+        assert.ok(!('console' in generatedAsyncAPI));
+        assert.ok(!generatedAsyncAPI.console);
     });
 });

--- a/test/lib/compile/asyncapiOptions.test.js
+++ b/test/lib/compile/asyncapiOptions.test.js
@@ -1,3 +1,5 @@
+const { describe, test, beforeEach } = require('node:test');
+const assert = require('node:assert');
 const toAsyncAPI = require('../../../lib/compile');
 const cds = require('@sap/cds');
 const { readdir, read, path: { resolve } } = cds.utils;
@@ -19,7 +21,7 @@ describe('asyncapi export: options', () => {
     const csn = cds.compile.to.csn(inputCDS);
     const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'base.json')));
     const generatedAsyncAPI = toAsyncAPI(csn);
-    expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+    assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
   });
 
   test('Service flag with an invalid service', async () => {
@@ -27,7 +29,7 @@ describe('asyncapi export: options', () => {
     const csn = cds.compile.to.csn(inputCDS);
 
     // throws error if service doesn't exist
-    expect(() => toAsyncAPI(csn, { service: 'foo' })).toThrowError(/not found/si);
+    assert.throws(() => toAsyncAPI(csn, { service: 'foo' }), /not found/i);
   });
 
   test('Service flag with a valid service name', async () => {
@@ -37,7 +39,7 @@ describe('asyncapi export: options', () => {
 
     // only generates one output if a service name is mentioned
     const generatedAsyncAPI = toAsyncAPI(csn, { service: 'com.sap.bookstore.BookStore' });
-    expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+    assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
   });
 
   test('Service flag set to all', async () => {
@@ -51,10 +53,10 @@ describe('asyncapi export: options', () => {
     const filesFound = new Set();
     for (const [content, metadata] of asyncapi) {
       const expectedAsyncAPI = metadata.file.split('.')[3] === 'BookStore' ? expectedBookStoreServiceOutput : expectedAuthorServiceOutput;
-      expect(content).toEqual(JSON.parse(expectedAsyncAPI));
+      assert.deepStrictEqual(content, JSON.parse(expectedAsyncAPI));
       filesFound.add(metadata.file);
     }
-    expect(filesFound).toEqual(new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService']));
+    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService']));
   });
 
   test('Service flag set to all with directory', async () => {
@@ -64,20 +66,20 @@ describe('asyncapi export: options', () => {
     });
 
     // generates two files for services set to all
-    const csn = await cds.compile(fileList).to.csn(); 
+    const csn = await cds.compile(fileList).to.csn();
     const generatedAsyncAPI = toAsyncAPI(csn, { service: 'all' });
     const filesFound = new Set();
     for (const [, metadata] of generatedAsyncAPI) {
       filesFound.add(metadata.file);
     }
-    expect(filesFound).toEqual(new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S']));
+    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S']));
   });
 
   test('Merged flag throws an error if title and version are not specified', async () => {
     const inputCDS = await read(join(baseInputPath, 'valid', 'multipleService.cds'));
     const csn = cds.compile.to.csn(inputCDS);
 
-    expect(() => toAsyncAPI(csn, { service: 'all', "asyncapi:merged": true })).toThrowError("Preset for Title and Version info needs to be added when merged flag is used.");
+    assert.throws(() => toAsyncAPI(csn, { service: 'all', "asyncapi:merged": true }), /Preset for Title and Version info needs to be added when merged flag is used\./);
   });
 
   test('Merged flag', async () => {
@@ -94,7 +96,7 @@ describe('asyncapi export: options', () => {
 
     // only generates one output if merged flag is mentioned
     const generatedAsyncAPI = toAsyncAPI(csn, { service: 'all', "asyncapi:merged": true });
-    expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+    assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
   });
 
 });

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -1,3 +1,5 @@
+const { describe, test, beforeEach } = require('node:test');
+const assert = require('node:assert');
 const cds = require('@sap/cds');
 const toAsyncAPI = require('../../../../../lib/compile');
 const { read } = cds.utils;
@@ -10,7 +12,7 @@ async function compileAndCheck(inputFile, outputFile) {
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)));
   const csn = cds.compile.to.csn(inputCDS);
   const generatedAsyncAPI = toAsyncAPI(csn);
-  expect(generatedAsyncAPI).toEqual(JSON.parse(expectedAsyncAPI));
+  assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI));
 }
 
 describe('asyncapi export: to json schema', () => {


### PR DESCRIPTION
Runs tests using the [native test runner](https://nodejs.org/api/test.html). Upgrades the test matrix to use Node 22 and 24, which are the current supported versions and are needed for the native test runner to work.