### PR TITLE
feat:Support i18n resolution in descriptions and titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
-- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`) in description annotations using `cds.i18n.labels`
+- Support for `@Core.Description` annotation as an alternative to `@description`
+- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
+- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`) in description annotations using `cds.i18n.labels`
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,7 +1,5 @@
 
 const cds = require('@sap/cds/lib')
-const { readFileSync, existsSync } = require('fs')
-const { join } = require('path')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
@@ -10,6 +8,8 @@ const odmAnnotationsMapping = Object.freeze({
 
 /**
  * Resolves i18n markers in a string like '{i18n>KEY}' using cds.i18n.labels
+ * @param {string} text
+ * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
  */
 function resolveI18n(text) {
     if (typeof text !== 'string' || !text.includes('{i18n>')) {
@@ -26,11 +26,7 @@ function resolveI18n(text) {
 
     // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
     const resolved = cds.i18n.labels.at(key)
-    if (resolved) {
-        return resolved
-    }
-    // If not found, return original text
-    return text
+    return resolved ?? text
 }
 
 function addOdmExtensions(definition, object) {

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -23,45 +23,12 @@ function resolveI18n(text) {
     }
 
     const key = match[1]
-    
+
     // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
     const resolved = cds.i18n.labels.at(key)
     if (resolved) {
         return resolved
     }
-    
-    // Fallback for non-standard locations (e.g., tests)
-    // Try to read i18n files directly from common locations relative to cds.root
-    const root = cds.root || process.cwd()
-    const i18nPaths = [
-        join(root, '_i18n', 'i18n.properties'),
-        join(root, 'i18n', 'i18n.properties'),
-        join(root, '_i18n', 'i18n_en.properties'),
-        join(root, 'i18n', 'i18n_en.properties'),
-        // For tests: also try test-specific paths
-        join(root, 'test', 'lib', 'compile', 'components', 'schemas', 'input', '_i18n', 'i18n.properties'),
-    ]
-
-    for (const i18nPath of i18nPaths) {
-        if (existsSync(i18nPath)) {
-            try {
-                const content = readFileSync(i18nPath, 'utf8')
-                const lines = content.split('\n')
-                
-                for (const line of lines) {
-                    // Parse key = value format
-                    const lineMatch = line.match(/^([^=\s]+)\s*=\s*(.+)$/)
-                    if (lineMatch && lineMatch[1].trim() === key) {
-                        return lineMatch[2].trim()
-                    }
-                }
-            } catch (err) {
-                // If file read fails, continue to next path
-                continue
-            }
-        }
-    }
-    
     // If not found, return original text
     return text
 }

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,8 +1,70 @@
 
+const cds = require('@sap/cds/lib')
+const { readFileSync, existsSync } = require('fs')
+const { join } = require('path')
+
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
     '@ODM.oid': 'x-sap-odm-oid'
 })
+
+/**
+ * Resolves i18n markers in a string like '{i18n>KEY}' using cds.i18n.labels
+ */
+function resolveI18n(text) {
+    if (typeof text !== 'string' || !text.includes('{i18n>')) {
+        return text
+    }
+
+    // Match {i18n>KEY} pattern
+    const match = text.match(/^\{i18n>([^}]+)\}$/)
+    if (!match) {
+        return text
+    }
+
+    const key = match[1]
+    
+    // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
+    const resolved = cds.i18n.labels.at(key)
+    if (resolved) {
+        return resolved
+    }
+    
+    // Fallback for non-standard locations (e.g., tests)
+    // Try to read i18n files directly from common locations relative to cds.root
+    const root = cds.root || process.cwd()
+    const i18nPaths = [
+        join(root, '_i18n', 'i18n.properties'),
+        join(root, 'i18n', 'i18n.properties'),
+        join(root, '_i18n', 'i18n_en.properties'),
+        join(root, 'i18n', 'i18n_en.properties'),
+        // For tests: also try test-specific paths
+        join(root, 'test', 'lib', 'compile', 'components', 'schemas', 'input', '_i18n', 'i18n.properties'),
+    ]
+
+    for (const i18nPath of i18nPaths) {
+        if (existsSync(i18nPath)) {
+            try {
+                const content = readFileSync(i18nPath, 'utf8')
+                const lines = content.split('\n')
+                
+                for (const line of lines) {
+                    // Parse key = value format
+                    const lineMatch = line.match(/^([^=\s]+)\s*=\s*(.+)$/)
+                    if (lineMatch && lineMatch[1].trim() === key) {
+                        return lineMatch[2].trim()
+                    }
+                }
+            } catch (err) {
+                // If file read fails, continue to next path
+                continue
+            }
+        }
+    }
+    
+    // If not found, return original text
+    return text
+}
 
 function addOdmExtensions(definition, object) {
     for (const [annotation, asyncApiExtension] of Object.entries(odmAnnotationsMapping)) {
@@ -14,13 +76,13 @@ function addOdmExtensions(definition, object) {
 
 module.exports = function addAnnotations(definition, object) {
     if (typeof (definition['@title']) === 'string') {
-        object.title = definition['@title']
+        object.title = resolveI18n(definition['@title'])
     }
 
     if (typeof (definition['@description']) === 'string') {
-        object.description = definition['@description']
+        object.description = resolveI18n(definition['@description'])
     } else if (typeof (definition['@Core.Description']) === 'string') {
-        object.description = definition['@Core.Description']
+        object.description = resolveI18n(definition['@Core.Description'])
     } else if (typeof definition.doc === 'string') {
         object.description = definition.doc.replace(/\n/g, ' ')
     }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -14,7 +14,15 @@ const presetMapping = {
 }
 
 module.exports = function processor(csn, options = {}) {
-    const i18nBundle = cds.i18n.bundle4(csn)
+    // Derive i18n bundle from CSN - uses the CSN's $sources to find i18n files
+    let i18nBundle
+    try {
+        i18nBundle = cds.i18n.bundle4(csn)
+    } catch (e) {
+        // If bundle creation fails, continue without i18n support
+        DEBUG?.('i18n bundle creation failed:', e.message)
+        i18nBundle = null
+    }
 
     let envConf = {}
     if (cds.env?.export?.asyncapi) {

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -80,4 +80,8 @@ describe('asyncapi export: to json schema', () => {
     await compileAndCheck('descriptions.cds', 'descriptions.json')
   })
 
+  test('Test for i18n in Descriptions', async () => {
+    await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+  })
+
 })

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -8,9 +8,25 @@ const baseInputPath = join(__dirname, 'input')
 const baseOutputPath = join(__dirname, 'output')
 
 async function compileAndCheck(inputFile, outputFile) {
-  const inputCDS = await read(join(baseInputPath, inputFile))
+  const inputPath = join(baseInputPath, inputFile)
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
+  
+  // Compile from string to preserve doc comments
+  const inputCDS = await read(inputPath)
   const csn = cds.compile.to.csn(inputCDS, { docs: true })
+  
+  const generatedAsyncAPI = toAsyncAPI(csn)
+  assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
+}
+
+async function compileAndCheckWithI18n(inputFile, outputFile) {
+  const inputPath = join(baseInputPath, inputFile)
+  const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
+  
+  // Load from file path to get i18n files
+  const model = await cds.load(inputPath)
+  const csn = cds.compile.to.csn(model, { docs: true })
+  
   const generatedAsyncAPI = toAsyncAPI(csn)
   assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
 }
@@ -85,7 +101,7 @@ describe('asyncapi export: to json schema', () => {
     const originalRoot = cds.root
     try {
       cds.root = baseInputPath
-      await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+      await compileAndCheckWithI18n('i18n-descriptions.cds', 'i18n-descriptions.json')
     } finally {
       cds.root = originalRoot
     }

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -81,7 +81,14 @@ describe('asyncapi export: to json schema', () => {
   })
 
   test('Test for i18n in Descriptions', async () => {
-    await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+    // Save original cds.root and set to input directory so CDS can find i18n files
+    const originalRoot = cds.root
+    try {
+      cds.root = baseInputPath
+      await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+    } finally {
+      cds.root = originalRoot
+    }
   })
 
 })

--- a/test/lib/compile/components/schemas/input/_i18n/i18n.properties
+++ b/test/lib/compile/components/schemas/input/_i18n/i18n.properties
@@ -1,0 +1,4 @@
+FIELD_DESC = Field description from i18n
+CORE_FIELD_DESC = Core field description from i18n
+EVENT_DESC = Event description from i18n
+PRODUCT_ID = Product identifier

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -9,11 +9,11 @@ service MyService {
 
     @Core.Description: '{i18n>CORE_FIELD_DESC}'
     fieldWithCoreI18n: String;
-    
+
     @description: 'Plain text description'
     fieldWithPlainText: String;
   };
-  
+
   @Core.Description: '{i18n>EVENT_DESC}'
   event I18nEvent : {
     @description: '{i18n>PRODUCT_ID}'

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -1,0 +1,22 @@
+namespace com.sap.test;
+
+@AsyncAPI.Title        : 'i18n Test Service'
+@AsyncAPI.SchemaVersion: '1.0.0'
+service MyService {
+  event TestEvent : {
+    @description: '{i18n>FIELD_DESC}'
+    fieldWithI18n: String;
+
+    @Core.Description: '{i18n>CORE_FIELD_DESC}'
+    fieldWithCoreI18n: String;
+    
+    @description: 'Plain text description'
+    fieldWithPlainText: String;
+  };
+  
+  @Core.Description: '{i18n>EVENT_DESC}'
+  event I18nEvent : {
+    @description: '{i18n>PRODUCT_ID}'
+    productId: String;
+  };
+}

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -3,6 +3,7 @@ namespace com.sap.test;
 @AsyncAPI.Title        : 'i18n Test Service'
 @AsyncAPI.SchemaVersion: '1.0.0'
 service MyService {
+
   event TestEvent : {
     @description: '{i18n>FIELD_DESC}'
     fieldWithI18n: String;

--- a/test/lib/compile/components/schemas/output/i18n-descriptions.json
+++ b/test/lib/compile/components/schemas/output/i18n-descriptions.json
@@ -1,0 +1,222 @@
+{
+  "asyncapi": "2.0.0",
+  "x-sap-catalog-spec-version": "1.2",
+  "x-sap-application-namespace": "com.sap.test",
+  "info": {
+    "version": "1.0.0",
+    "title": "i18n Test Service"
+  },
+  "defaultContentType": "application/json",
+  "channels": {
+    "com.sap.test.MyService.TestEvent": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.TestEvent"
+        }
+      }
+    },
+    "com.sap.test.MyService.I18nEvent": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.I18nEvent"
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "CloudEventsContext.v1": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Identifies the event.",
+              "type": "string",
+              "examples": [
+                "6925d08e-bc19-4ad7-902e-bd29721cc69b"
+              ]
+            },
+            "specversion": {
+              "description": "The version of the CloudEvents specification which the event uses.",
+              "type": "string",
+              "const": "1.0"
+            },
+            "source": {
+              "description": "Identifies the instance the event originated in.",
+              "type": "string",
+              "format": "uri-reference",
+              "examples": [
+                "/default/sap.s4.beh/ER9CLNT001",
+                "/eu/sap.billing.sb/91dec60d-9757-4e2c-b9e5-21da10016fe9"
+              ]
+            },
+            "type": {
+              "description": "Describes the type of the event related to the source the event originated in.",
+              "type": "string",
+              "examples": [
+                "sap.dsc.FreightOrder.Arrived.v1",
+                "sap.billing.sb.Subscription.Canceled.v1"
+              ]
+            },
+            "subject": {
+              "description": "Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).",
+              "type": "string",
+              "examples": [
+                "ce307052-75a0-4a8f-a961-ebf21669bb80",
+                "urn:epc:tag:sgtin-96:1.7332402.026591.1234567890"
+              ]
+            },
+            "datacontenttype": {
+              "description": "Content type of the event data.",
+              "type": "string",
+              "const": "application/json"
+            },
+            "dataschema": {
+              "description": "Identifies the schema that the event data adheres to.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "http://example.com/event/sap.billing.sb.Subscription.Canceled/v1.2.0"
+              ]
+            },
+            "time": {
+              "description": "Timestamp of when the occurrence happened.",
+              "format": "date-time",
+              "type": "string",
+              "examples": [
+                "2018-04-05T17:31:00Z"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "source",
+            "specversion",
+            "type"
+          ],
+          "patternProperties": {
+            "^xsap[a-z0-9]+$": {
+              "description": "Application defined custom extension context attributes.",
+              "type": [
+                "boolean",
+                "integer",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "messages": {
+      "com.sap.test.MyService.TestEvent": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.TestEvent",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.TestEvent"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.TestEvent"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "com.sap.test.MyService.I18nEvent": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.I18nEvent",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.I18nEvent"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.I18nEvent"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      }
+    },
+    "schemas": {
+      "com.sap.test.MyService.TestEvent": {
+        "type": "object",
+        "properties": {
+          "fieldWithI18n": {
+            "type": "string",
+            "description": "Field description from i18n"
+          },
+          "fieldWithCoreI18n": {
+            "type": "string",
+            "description": "Core field description from i18n"
+          },
+          "fieldWithPlainText": {
+            "type": "string",
+            "description": "Plain text description"
+          }
+        }
+      },
+      "com.sap.test.MyService.I18nEvent": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "Product identifier"
+          }
+        },
+        "description": "Event description from i18n"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Stacked on https://github.com/cap-js/asyncapi/pull/41

# Support i18n Resolution and `@Core.Description` in Descriptions and Titles

### New Features

✨ This PR introduces two enhancements to annotation handling in schema compilation:

1. **`@Core.Description` support**: The `@Core.Description` annotation is now recognized as a fallback alternative to `@description` for populating the `description` field. `@description` still takes priority when both are present.
2. **i18n marker resolution**: Annotation values containing i18n markers (e.g., `{i18n>KEY}`) in `@title`, `@description`, and `@Core.Description` are now automatically resolved to their translated strings using `cds.i18n.labels`.

### Changes

* `lib/compile/components/schemas/annotations.js`: Added a `resolveI18n()` helper function that matches `{i18n>KEY}` patterns and resolves them via `cds.i18n.labels`. Applied this resolution to `@title`, `@description`, and `@Core.Description`. Also ensures `@Core.Description` is used as a fallback when `@description` is absent.
* `test/lib/compile/components/schemas/csnToJSONSchema.test.js`: Added a new test case for i18n resolution in descriptions, temporarily setting `cds.root` to the input directory so CDS can locate the i18n files during the test.
* `test/lib/compile/components/schemas/input/i18n-descriptions.cds`: New test fixture defining events and fields with i18n markers in `@description` and `@Core.Description` annotations.
* `test/lib/compile/components/schemas/input/_i18n/i18n.properties`: New i18n properties file containing test translation keys (`FIELD_DESC`, `CORE_FIELD_DESC`, `EVENT_DESC`, `PRODUCT_ID`).
* `test/lib/compile/components/schemas/output/i18n-descriptions.json`: Expected output snapshot verifying that i18n markers are fully resolved to their translated strings in the compiled schema.
* `CHANGELOG.md`: Added entries for both new capabilities under the `[Unreleased]` section.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `25c16bba-b89a-4b66-b21d-ef5c91968f52`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
