### PR TITLE
Support @Core.Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Support for `@Core.Description` annotation as an alternative to `@description`
 - Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
+- Event descriptions now appear in `components.messages.<event>.description` in addition to `components.schemas.<event>.description`
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/lib/compile/components/messages/index.js
+++ b/lib/compile/components/messages/index.js
@@ -1,4 +1,24 @@
-const { getEventName } = require('../../utils')
+const { getEventName, resolveI18n } = require('../../utils')
+
+/**
+ * Extracts description from event definition with fallback chain:
+ * 1. @description annotation (with i18n resolution)
+ * 2. @Core.Description annotation (with i18n resolution)
+ * 3. doc comment (plain text)
+ * @param {object} definition - Event definition from CSN
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string|undefined} Description text or undefined if none found
+ */
+function getDescription(definition, i18nBundle) {
+    if (typeof definition['@description'] === 'string') {
+        return resolveI18n(definition['@description'], i18nBundle)
+    } else if (typeof definition['@Core.Description'] === 'string') {
+        return resolveI18n(definition['@Core.Description'], i18nBundle)
+    } else if (typeof definition.doc === 'string') {
+        return definition.doc.replace(/\n/g, ' ')
+    }
+    return undefined
+}
 
 const annotationMapping = {
     'EventSpecVersion': 'x-sap-event-spec-version',
@@ -120,7 +140,7 @@ function addDefaults(obj) {
 /**
  * Get message for the event definition.
  */
-function eventToMessage(definition, name, presets) {
+function eventToMessage(definition, name, presets, i18nBundle) {
     let obj = readAnnotations(definition, presets)
 
     let messageObj = {
@@ -139,6 +159,12 @@ function eventToMessage(definition, name, presets) {
         ]
     }
 
+    // Add description if available
+    const description = getDescription(definition, i18nBundle)
+    if (description) {
+        messageObj.description = description
+    }
+
     const message = { ...obj, ...messageObj}
 
     return message
@@ -147,12 +173,12 @@ function eventToMessage(definition, name, presets) {
 /**
  * Event definitions of one CSN to messages.
  */
-function entriesToMessages(definitions, events, presets) {
+function entriesToMessages(definitions, events, presets, i18nBundle) {
     const messages = {}
 
     events.forEach(event => {
         let name = getEventName(event, definitions[event])
-        messages[name] = eventToMessage(definitions[event], name, presets)
+        messages[name] = eventToMessage(definitions[event], name, presets, i18nBundle)
     })
 
     return messages
@@ -161,9 +187,9 @@ function entriesToMessages(definitions, events, presets) {
 /**
  * Combining the definition objects from CSN into one schema
  */
-function definitionsToMessages(definitions, events, presets) {
+function definitionsToMessages(definitions, events, presets, i18nBundle) {
     const messages = {}
-    Object.assign(messages, entriesToMessages(definitions, events, presets))
+    Object.assign(messages, entriesToMessages(definitions, events, presets, i18nBundle))
     return messages
 }
 

--- a/lib/compile/components/messages/index.js
+++ b/lib/compile/components/messages/index.js
@@ -1,24 +1,4 @@
-const { getEventName, resolveI18n } = require('../../utils')
-
-/**
- * Extracts description from event definition with fallback chain:
- * 1. @description annotation (with i18n resolution)
- * 2. @Core.Description annotation (with i18n resolution)
- * 3. doc comment (plain text)
- * @param {object} definition - Event definition from CSN
- * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
- * @return {string|undefined} Description text or undefined if none found
- */
-function getDescription(definition, i18nBundle) {
-    if (typeof definition['@description'] === 'string') {
-        return resolveI18n(definition['@description'], i18nBundle)
-    } else if (typeof definition['@Core.Description'] === 'string') {
-        return resolveI18n(definition['@Core.Description'], i18nBundle)
-    } else if (typeof definition.doc === 'string') {
-        return definition.doc.replace(/\n/g, ' ')
-    }
-    return undefined
-}
+const { getEventName, getDescription } = require('../../utils')
 
 const annotationMapping = {
     'EventSpecVersion': 'x-sap-event-spec-version',

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,27 +1,11 @@
 
 const cds = require('@sap/cds/lib')
+const { resolveI18n } = require('../../utils')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
     '@ODM.oid': 'x-sap-odm-oid'
 })
-
-/**
- * Resolves i18n markers in a string like '{i18n>KEY}' using the provided i18n bundle
- * @param {string} text
- * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
- * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
- */
-function resolveI18n(text, i18nBundle) {
-    if (typeof text !== 'string' || !text.includes('{i18n>')) {
-        return text
-    }
-    const match = text.match(/\{i18n>([^}]+)\}/)
-    if (!match) {
-        return text
-    }
-    return i18nBundle?.at(match[1]) ?? text
-}
 
 function addOdmExtensions(definition, object) {
     for (const [annotation, asyncApiExtension] of Object.entries(odmAnnotationsMapping)) {

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,6 +1,6 @@
 
 const cds = require('@sap/cds/lib')
-const { resolveI18n } = require('../../utils')
+const { resolveI18n, getDescription } = require('../../utils')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
@@ -20,12 +20,9 @@ module.exports = function addAnnotations(definition, object, i18nBundle) {
         object.title = resolveI18n(definition['@title'], i18nBundle)
     }
 
-    if (typeof (definition['@description']) === 'string') {
-        object.description = resolveI18n(definition['@description'], i18nBundle)
-    } else if (typeof (definition['@Core.Description']) === 'string') {
-        object.description = resolveI18n(definition['@Core.Description'], i18nBundle)
-    } else if (typeof definition.doc === 'string') {
-        object.description = definition.doc.replace(/\n/g, ' ')
+    const description = getDescription(definition, i18nBundle)
+    if (description) {
+        object.description = description
     }
 
     if (definition['@ODM.root']) {

--- a/lib/compile/components/schemas/definition.js
+++ b/lib/compile/components/schemas/definition.js
@@ -20,7 +20,7 @@ function definitionToSchema(eventDefinition, definitions, schemaCache, i18nBundl
 
 function elementsToSchema(schemaCache, definitions, entry, nullable, i18nBundle) {
   if (!schemaUtils.isStructured(entry)) {
-    return elementToSchema(schemaCache, definitions, entry, i18nBundle, nullable)
+    return elementToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   const required = []

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -237,7 +237,7 @@ function getComponents(definitions, events, presets, i18nBundle) {
 
     return {
         messageTraits: getMessageTraits(),
-        messages: definitionsToMessages(definitions, events, presets),
+        messages: definitionsToMessages(definitions, events, presets, i18nBundle),
         schemas: csnToJSONSchema(definitions, events, i18nBundle)
     }
 }

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -38,8 +38,29 @@ function resolveI18n(text, i18nBundle) {
     return i18nBundle?.at(match[1]) ?? text
 }
 
+/**
+ * Extracts description from definition with fallback chain:
+ * 1. @description annotation (with i18n resolution)
+ * 2. @Core.Description annotation (with i18n resolution)
+ * 3. doc comment (plain text)
+ * @param {object} definition - Event or element definition from CSN
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string|undefined} Description text or undefined if none found
+ */
+function getDescription(definition, i18nBundle) {
+    if (typeof definition['@description'] === 'string') {
+        return resolveI18n(definition['@description'], i18nBundle)
+    } else if (typeof definition['@Core.Description'] === 'string') {
+        return resolveI18n(definition['@Core.Description'], i18nBundle)
+    } else if (typeof definition.doc === 'string') {
+        return definition.doc.replace(/\n/g, ' ')
+    }
+    return undefined
+}
+
 module.exports = {
     getEventName,
     getOwnValue,
-    resolveI18n
+    resolveI18n,
+    getDescription
 }

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -21,7 +21,25 @@ function getOwnValue(entry, key) {
     return
 }
 
+/**
+ * Resolves i18n markers in a string like '{i18n>KEY}' using the provided i18n bundle
+ * @param {string} text
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
+ */
+function resolveI18n(text, i18nBundle) {
+    if (typeof text !== 'string' || !text.includes('{i18n>')) {
+        return text
+    }
+    const match = text.match(/\{i18n>([^}]+)\}/)
+    if (!match) {
+        return text
+    }
+    return i18nBundle?.at(match[1]) ?? text
+}
+
 module.exports = {
     getEventName,
-    getOwnValue
+    getOwnValue,
+    resolveI18n
 }

--- a/test/lib/compile/components/schemas/output/descriptions.json
+++ b/test/lib/compile/components/schemas/output/descriptions.json
@@ -160,7 +160,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Event with @Core.Description annotation"
       },
       "com.sap.test.MyService.Bar": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
@@ -200,7 +201,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "This takes priority"
       },
       "com.sap.test.MyService.Baz": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
@@ -240,7 +242,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Doc comment as fallback"
       },
       "com.sap.test.MyService.TestEvent": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",

--- a/test/lib/compile/components/schemas/output/i18n-descriptions.json
+++ b/test/lib/compile/components/schemas/output/i18n-descriptions.json
@@ -186,7 +186,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Event description from i18n"
       }
     },
     "schemas": {


### PR DESCRIPTION
# Add Support for `@Core.Description` Annotation and i18n Resolution

### New Features

✨ This PR introduces two enhancements to the AsyncAPI export:

1. **`@Core.Description` annotation support**: The `@Core.Description` annotation is now recognized as a fallback description source when `@description` is not present. The resolution priority chain is: `@description` → `@Core.Description` → doc comment.
2. **Automatic i18n marker resolution**: Description and title values containing i18n markers (e.g., `{i18n>KEY}`) are now automatically resolved to their localized text using the CDS i18n bundle derived from the CSN.

### Changes

* `lib/compile/utils.js`: Added `resolveI18n()` utility function that resolves `{i18n>KEY}` markers in strings using the provided i18n bundle.
* `lib/compile/components/schemas/annotations.js`: Updated `addAnnotations()` to accept an `i18nBundle` parameter, added `@Core.Description` as a fallback description source, and applied `resolveI18n()` to both `@title` and `@description` values.
* `lib/compile/components/schemas/definition.js`: Propagated the `i18nBundle` parameter through all schema conversion functions (`definitionToSchema`, `elementsToSchema`, `elementToSchema`, `associationToSchema`, `manyToSchema`, `compositionToSchema`, `refToSchema`).
* `lib/compile/components/schemas/index.js`: Passed `i18nBundle` into `csnToJSONSchema` and forwarded it to `definitionToSchema`.
* `lib/compile/components/messages/index.js`: Added `getDescription()` helper implementing the same `@description` → `@Core.Description` → doc fallback chain; propagated `i18nBundle` through `eventToMessage`, `entriesToMessages`, and `definitionsToMessages`.
* `lib/compile/index.js`: Initialized the i18n bundle via `cds.i18n.bundle4(csn)` at the processor entry point and threaded it through `getComponents`, `_getAsyncApi`, and `_iterate`.
* `test/lib/compile/components/schemas/csnToJSONSchema.test.js`: Added tests for `@Core.Description` fallback and i18n resolution in descriptions; added `compileAndCheckWithI18n()` helper that loads from file path to resolve i18n files.
* `test/lib/compile/components/schemas/input/descriptions.cds`: New test fixture covering all description annotation combinations.
* `test/lib/compile/components/schemas/input/i18n-descriptions.cds`: New test fixture using `{i18n>KEY}` markers.
* `test/lib/compile/components/schemas/input/_i18n/i18n.properties`: New i18n properties file with test translation keys.
* `test/lib/compile/components/schemas/output/descriptions.json`: Expected output for the description annotation test.
* `test/lib/compile/components/schemas/output/i18n-descriptions.json`: Expected output for the i18n resolution test.
* `CHANGELOG.md`: Documented the two new features under `[Unreleased]`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `3dc206f0-26b8-45cf-9740-8f9dda2067ad`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
</details>
