### PR TITLE
Allow customisation of default examples in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
-- Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
-- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`) in description annotations using `cds.i18n.labels`
+- Support for `@Core.Description` annotation as an alternative to `@description`
+- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
+- Support for i18n labels inside description and title annotations
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support for `@Core.Description` annotation as an alternative to `@description`
 - Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
 - Event descriptions now appear in `components.messages.<event>.description` in addition to `components.schemas.<event>.description`
+- CloudEvents header examples can now be customized via `cds.env.export.asyncapi.cloudevents_examples` configuration
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
+
 ## Version 1.0.3 - 12-03-2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Support for `@Core.Description` annotation as an alternative to `@description`, aligned with OpenAPI behavior
+- Automatic resolution of i18n markers (e.g., `{i18n>KEY}`) in description annotations using `cds.i18n.labels`
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Support for `@Core.Description` annotation as an alternative to `@description`
 - Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
+- Event descriptions now appear in `components.messages.<event>.description` in addition to `components.schemas.<event>.description`
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/lib/compile/components/messageTraits/index.js
+++ b/lib/compile/components/messageTraits/index.js
@@ -1,7 +1,9 @@
 /**
  * Get a map of message traits.
+ * @param {object} presets - Optional preset configuration including cloudevents_examples
  */
-module.exports = function getMessageTraits() {
+module.exports = function getMessageTraits(presets = {}) {
+    const customExamples = presets.cloudevents_examples || {}
 
     return {
         'CloudEventsContext.v1': {
@@ -24,7 +26,7 @@ module.exports = function getMessageTraits() {
                         'description': 'Identifies the instance the event originated in.',
                         'type': 'string',
                         'format': 'uri-reference',
-                        'examples': [
+                        'examples': customExamples.source || [
                             '/default/sap.s4.beh/ER9CLNT001',
                             '/eu/sap.billing.sb/91dec60d-9757-4e2c-b9e5-21da10016fe9'
                         ]
@@ -32,7 +34,7 @@ module.exports = function getMessageTraits() {
                     'type': {
                         'description': 'Describes the type of the event related to the source the event originated in.',
                         'type': 'string',
-                        'examples': [
+                        'examples': customExamples.type || [
                             'sap.dsc.FreightOrder.Arrived.v1',
                             'sap.billing.sb.Subscription.Canceled.v1'
                         ]
@@ -40,7 +42,7 @@ module.exports = function getMessageTraits() {
                     'subject': {
                         'description': 'Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).',
                         'type': 'string',
-                        'examples': [
+                        'examples': customExamples.subject || [
                             'ce307052-75a0-4a8f-a961-ebf21669bb80',
                             'urn:epc:tag:sgtin-96:1.7332402.026591.1234567890'
                         ]
@@ -54,7 +56,7 @@ module.exports = function getMessageTraits() {
                         'description': 'Identifies the schema that the event data adheres to.',
                         'type': 'string',
                         'format': 'uri',
-                        'examples': [
+                        'examples': customExamples.dataschema || [
                             'http://example.com/event/sap.billing.sb.Subscription.Canceled/v1.2.0'
                         ]
                     },

--- a/lib/compile/components/messages/index.js
+++ b/lib/compile/components/messages/index.js
@@ -1,4 +1,24 @@
-const { getEventName } = require('../../utils')
+const { getEventName, resolveI18n } = require('../../utils')
+
+/**
+ * Extracts description from event definition with fallback chain:
+ * 1. @description annotation (with i18n resolution)
+ * 2. @Core.Description annotation (with i18n resolution)
+ * 3. doc comment (plain text)
+ * @param {object} definition - Event definition from CSN
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string|undefined} Description text or undefined if none found
+ */
+function getDescription(definition, i18nBundle) {
+    if (typeof definition['@description'] === 'string') {
+        return resolveI18n(definition['@description'], i18nBundle)
+    } else if (typeof definition['@Core.Description'] === 'string') {
+        return resolveI18n(definition['@Core.Description'], i18nBundle)
+    } else if (typeof definition.doc === 'string') {
+        return definition.doc.replace(/\n/g, ' ')
+    }
+    return undefined
+}
 
 const annotationMapping = {
     'EventSpecVersion': 'x-sap-event-spec-version',
@@ -120,7 +140,7 @@ function addDefaults(obj) {
 /**
  * Get message for the event definition.
  */
-function eventToMessage(definition, name, presets) {
+function eventToMessage(definition, name, presets, i18nBundle) {
     let obj = readAnnotations(definition, presets)
 
     let messageObj = {
@@ -139,6 +159,12 @@ function eventToMessage(definition, name, presets) {
         ]
     }
 
+    // Add description if available
+    const description = getDescription(definition, i18nBundle)
+    if (description) {
+        messageObj.description = description
+    }
+
     const message = { ...obj, ...messageObj}
 
     return message
@@ -147,12 +173,12 @@ function eventToMessage(definition, name, presets) {
 /**
  * Event definitions of one CSN to messages.
  */
-function entriesToMessages(definitions, events, presets) {
+function entriesToMessages(definitions, events, presets, i18nBundle) {
     const messages = {}
 
     events.forEach(event => {
         let name = getEventName(event, definitions[event])
-        messages[name] = eventToMessage(definitions[event], name, presets)
+        messages[name] = eventToMessage(definitions[event], name, presets, i18nBundle)
     })
 
     return messages
@@ -161,9 +187,9 @@ function entriesToMessages(definitions, events, presets) {
 /**
  * Combining the definition objects from CSN into one schema
  */
-function definitionsToMessages(definitions, events, presets) {
+function definitionsToMessages(definitions, events, presets, i18nBundle) {
     const messages = {}
-    Object.assign(messages, entriesToMessages(definitions, events, presets))
+    Object.assign(messages, entriesToMessages(definitions, events, presets, i18nBundle))
     return messages
 }
 

--- a/lib/compile/components/messages/index.js
+++ b/lib/compile/components/messages/index.js
@@ -1,24 +1,4 @@
-const { getEventName, resolveI18n } = require('../../utils')
-
-/**
- * Extracts description from event definition with fallback chain:
- * 1. @description annotation (with i18n resolution)
- * 2. @Core.Description annotation (with i18n resolution)
- * 3. doc comment (plain text)
- * @param {object} definition - Event definition from CSN
- * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
- * @return {string|undefined} Description text or undefined if none found
- */
-function getDescription(definition, i18nBundle) {
-    if (typeof definition['@description'] === 'string') {
-        return resolveI18n(definition['@description'], i18nBundle)
-    } else if (typeof definition['@Core.Description'] === 'string') {
-        return resolveI18n(definition['@Core.Description'], i18nBundle)
-    } else if (typeof definition.doc === 'string') {
-        return definition.doc.replace(/\n/g, ' ')
-    }
-    return undefined
-}
+const { getEventName, getDescription } = require('../../utils')
 
 const annotationMapping = {
     'EventSpecVersion': 'x-sap-event-spec-version',

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -4,6 +4,25 @@ const odmAnnotationsMapping = Object.freeze({
     '@ODM.oid': 'x-sap-odm-oid'
 })
 
+/**
+ * Resolves i18n markers in a string like '{i18n>KEY}' using the provided i18n bundle
+ * @param {string} text
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
+ */
+function resolveI18n(text, i18nBundle) {
+    if (typeof text !== 'string' || !text.includes('{i18n>')) {
+        return text
+    }
+
+    // Match {i18n>KEY} pattern
+    const match = text.match(/\{i18n>([^}]+)\}/)
+    if (!match) {
+        return text
+    }
+    return i18nBundle?.at(match[1]) ?? text
+}
+
 function addOdmExtensions(definition, object) {
     for (const [annotation, asyncApiExtension] of Object.entries(odmAnnotationsMapping)) {
         if (definition[annotation]) {
@@ -12,15 +31,15 @@ function addOdmExtensions(definition, object) {
     }
 }
 
-module.exports = function addAnnotations(definition, object) {
+module.exports = function addAnnotations(definition, object, i18nBundle) {
     if (typeof (definition['@title']) === 'string') {
-        object.title = definition['@title']
+        object.title = resolveI18n(definition['@title'], i18nBundle)
     }
 
     if (typeof (definition['@description']) === 'string') {
-        object.description = definition['@description']
+        object.description = resolveI18n(definition['@description'], i18nBundle)
     } else if (typeof (definition['@Core.Description']) === 'string') {
-        object.description = definition['@Core.Description']
+        object.description = resolveI18n(definition['@Core.Description'], i18nBundle)
     } else if (typeof definition.doc === 'string') {
         object.description = definition.doc.replace(/\n/g, ' ')
     }

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,7 +1,5 @@
 
 const cds = require('@sap/cds/lib')
-const { readFileSync, existsSync } = require('fs')
-const { join } = require('path')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
@@ -10,6 +8,8 @@ const odmAnnotationsMapping = Object.freeze({
 
 /**
  * Resolves i18n markers in a string like '{i18n>KEY}' using cds.i18n.labels
+ * @param {string} text
+ * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
  */
 function resolveI18n(text) {
     if (typeof text !== 'string' || !text.includes('{i18n>')) {
@@ -26,11 +26,7 @@ function resolveI18n(text) {
 
     // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
     const resolved = cds.i18n.labels.at(key)
-    if (resolved) {
-        return resolved
-    }
-    // If not found, return original text
-    return text
+    return resolved ?? text
 }
 
 function addOdmExtensions(definition, object) {

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -23,45 +23,12 @@ function resolveI18n(text) {
     }
 
     const key = match[1]
-    
+
     // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
     const resolved = cds.i18n.labels.at(key)
     if (resolved) {
         return resolved
     }
-    
-    // Fallback for non-standard locations (e.g., tests)
-    // Try to read i18n files directly from common locations relative to cds.root
-    const root = cds.root || process.cwd()
-    const i18nPaths = [
-        join(root, '_i18n', 'i18n.properties'),
-        join(root, 'i18n', 'i18n.properties'),
-        join(root, '_i18n', 'i18n_en.properties'),
-        join(root, 'i18n', 'i18n_en.properties'),
-        // For tests: also try test-specific paths
-        join(root, 'test', 'lib', 'compile', 'components', 'schemas', 'input', '_i18n', 'i18n.properties'),
-    ]
-
-    for (const i18nPath of i18nPaths) {
-        if (existsSync(i18nPath)) {
-            try {
-                const content = readFileSync(i18nPath, 'utf8')
-                const lines = content.split('\n')
-                
-                for (const line of lines) {
-                    // Parse key = value format
-                    const lineMatch = line.match(/^([^=\s]+)\s*=\s*(.+)$/)
-                    if (lineMatch && lineMatch[1].trim() === key) {
-                        return lineMatch[2].trim()
-                    }
-                }
-            } catch (err) {
-                // If file read fails, continue to next path
-                continue
-            }
-        }
-    }
-    
     // If not found, return original text
     return text
 }

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -19,6 +19,8 @@ module.exports = function addAnnotations(definition, object) {
 
     if (typeof (definition['@description']) === 'string') {
         object.description = definition['@description'];
+    } else if (typeof (definition['@Core.Description']) === 'string') {
+        object.description = definition['@Core.Description'];
     } else if (typeof definition.doc === 'string') {
         object.description = definition.doc.replace(/\n/g, ' ');
     }

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,27 +1,11 @@
 
 const cds = require('@sap/cds/lib')
+const { resolveI18n } = require('../../utils')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
     '@ODM.oid': 'x-sap-odm-oid'
 })
-
-/**
- * Resolves i18n markers in a string like '{i18n>KEY}' using the provided i18n bundle
- * @param {string} text
- * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
- * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
- */
-function resolveI18n(text, i18nBundle) {
-    if (typeof text !== 'string' || !text.includes('{i18n>')) {
-        return text
-    }
-    const match = text.match(/\{i18n>([^}]+)\}/)
-    if (!match) {
-        return text
-    }
-    return i18nBundle?.at(match[1]) ?? text
-}
 
 function addOdmExtensions(definition, object) {
     for (const [annotation, asyncApiExtension] of Object.entries(odmAnnotationsMapping)) {

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,8 +1,70 @@
 
+const cds = require('@sap/cds/lib')
+const { readFileSync, existsSync } = require('fs')
+const { join } = require('path')
+
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
     '@ODM.oid': 'x-sap-odm-oid'
 })
+
+/**
+ * Resolves i18n markers in a string like '{i18n>KEY}' using cds.i18n.labels
+ */
+function resolveI18n(text) {
+    if (typeof text !== 'string' || !text.includes('{i18n>')) {
+        return text
+    }
+
+    // Match {i18n>KEY} pattern
+    const match = text.match(/^\{i18n>([^}]+)\}$/)
+    if (!match) {
+        return text
+    }
+
+    const key = match[1]
+    
+    // Use cds.i18n.labels to resolve the key (works when i18n files are in standard location)
+    const resolved = cds.i18n.labels.at(key)
+    if (resolved) {
+        return resolved
+    }
+    
+    // Fallback for non-standard locations (e.g., tests)
+    // Try to read i18n files directly from common locations relative to cds.root
+    const root = cds.root || process.cwd()
+    const i18nPaths = [
+        join(root, '_i18n', 'i18n.properties'),
+        join(root, 'i18n', 'i18n.properties'),
+        join(root, '_i18n', 'i18n_en.properties'),
+        join(root, 'i18n', 'i18n_en.properties'),
+        // For tests: also try test-specific paths
+        join(root, 'test', 'lib', 'compile', 'components', 'schemas', 'input', '_i18n', 'i18n.properties'),
+    ]
+
+    for (const i18nPath of i18nPaths) {
+        if (existsSync(i18nPath)) {
+            try {
+                const content = readFileSync(i18nPath, 'utf8')
+                const lines = content.split('\n')
+                
+                for (const line of lines) {
+                    // Parse key = value format
+                    const lineMatch = line.match(/^([^=\s]+)\s*=\s*(.+)$/)
+                    if (lineMatch && lineMatch[1].trim() === key) {
+                        return lineMatch[2].trim()
+                    }
+                }
+            } catch (err) {
+                // If file read fails, continue to next path
+                continue
+            }
+        }
+    }
+    
+    // If not found, return original text
+    return text
+}
 
 function addOdmExtensions(definition, object) {
     for (const [annotation, asyncApiExtension] of Object.entries(odmAnnotationsMapping)) {
@@ -14,13 +76,13 @@ function addOdmExtensions(definition, object) {
 
 module.exports = function addAnnotations(definition, object) {
     if (typeof (definition['@title']) === 'string') {
-        object.title = definition['@title']
+        object.title = resolveI18n(definition['@title'])
     }
 
     if (typeof (definition['@description']) === 'string') {
-        object.description = definition['@description']
+        object.description = resolveI18n(definition['@description'])
     } else if (typeof (definition['@Core.Description']) === 'string') {
-        object.description = definition['@Core.Description']
+        object.description = resolveI18n(definition['@Core.Description'])
     } else if (typeof definition.doc === 'string') {
         object.description = definition.doc.replace(/\n/g, ' ')
     }

--- a/lib/compile/components/schemas/annotations.js
+++ b/lib/compile/components/schemas/annotations.js
@@ -1,6 +1,6 @@
 
 const cds = require('@sap/cds/lib')
-const { resolveI18n } = require('../../utils')
+const { resolveI18n, getDescription } = require('../../utils')
 
 const odmAnnotationsMapping = Object.freeze({
     '@ODM.entityName': 'x-sap-odm-entity-name',
@@ -20,12 +20,9 @@ module.exports = function addAnnotations(definition, object, i18nBundle) {
         object.title = resolveI18n(definition['@title'], i18nBundle)
     }
 
-    if (typeof (definition['@description']) === 'string') {
-        object.description = resolveI18n(definition['@description'], i18nBundle)
-    } else if (typeof (definition['@Core.Description']) === 'string') {
-        object.description = resolveI18n(definition['@Core.Description'], i18nBundle)
-    } else if (typeof definition.doc === 'string') {
-        object.description = definition.doc.replace(/\n/g, ' ')
+    const description = getDescription(definition, i18nBundle)
+    if (description) {
+        object.description = description
     }
 
     if (definition['@ODM.root']) {

--- a/lib/compile/components/schemas/definition.js
+++ b/lib/compile/components/schemas/definition.js
@@ -8,19 +8,19 @@ const primitiveElementToSchema = require('./primitiveElement')
 const getArrayOfType= require('./array')
 const { followRefRecursive } = require('./ref')
 
-function definitionToSchema(eventDefinition, definitions, schemaCache) {
+function definitionToSchema(eventDefinition, definitions, schemaCache, i18nBundle) {
   const definition = definitions[eventDefinition]
 
   if (schemaUtils.isStructured(definition)) {
-    return addAnnotations(definition, elementsToSchema(schemaCache, definitions, definition))
+    return addAnnotations(definition, elementsToSchema(schemaCache, definitions, definition, undefined, i18nBundle), i18nBundle)
   }
 
-  return addAnnotations(definition, elementToSchema(schemaCache, definitions, definition))
+  return addAnnotations(definition, elementToSchema(schemaCache, definitions, definition, i18nBundle), i18nBundle)
 }
 
-function elementsToSchema(schemaCache, definitions, entry, nullable) {
+function elementsToSchema(schemaCache, definitions, entry, nullable, i18nBundle) {
   if (!schemaUtils.isStructured(entry)) {
-    return elementToSchema(schemaCache, definitions, entry, nullable)
+    return elementToSchema(schemaCache, definitions, entry, i18nBundle, nullable)
   }
 
   const required = []
@@ -41,7 +41,7 @@ function elementsToSchema(schemaCache, definitions, entry, nullable) {
       object.properties = {}
     }
 
-    object.properties[name] = addAnnotations(element, elementToSchema(schemaCache, definitions, element))
+    object.properties[name] = addAnnotations(element, elementToSchema(schemaCache, definitions, element, i18nBundle), i18nBundle)
   }
 
   if (required.length) {
@@ -51,7 +51,7 @@ function elementsToSchema(schemaCache, definitions, entry, nullable) {
   return object
 }
 
-function elementToSchema(schemaCache, definitions, entry) {
+function elementToSchema(schemaCache, definitions, entry, i18nBundle) {
   /*
    * Process reuse types as first step.
    * A structured type will be preprocessed and 'elements' will exists as inherited prototype.
@@ -65,33 +65,33 @@ function elementToSchema(schemaCache, definitions, entry) {
     }
 
     return cacheAndReturn(schemaCache, entry.type,
-      elementToSchema(schemaCache, definitions, definitions[entry.type])
+      elementToSchema(schemaCache, definitions, definitions[entry.type], i18nBundle)
     )
   }
 
   // Process anonymous attribute object structures like "deep: {deeper: {attr: String;};};"
   if (schemaUtils.isStructured(entry)) {
-    return elementsToSchema(schemaCache, definitions, entry)
+    return elementsToSchema(schemaCache, definitions, entry, undefined, i18nBundle)
   }
 
   // Arrayed primitives and structured objects without keyed property
   if (schemaUtils.isManyEntry(entry)) {
-    return manyToSchema(schemaCache, definitions, entry)
+    return manyToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   // Definition > element references
   if (schemaUtils.isRefEntry(entry)) {
-    return refToSchema(schemaCache, definitions, entry)
+    return refToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   // Associations to (root) entities and code lists
   if (schemaUtils.isAssociation(entry)) {
-    return associationToSchema(schemaCache, definitions, entry)
+    return associationToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   // Compositions of aspect or entity
   if (schemaUtils.isComposition(entry)) {
-    return compositionToSchema(schemaCache, definitions, entry)
+    return compositionToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   //A localized element is a primitive at CSN and an array of objects at JSON schema (all translations)
@@ -99,7 +99,7 @@ function elementToSchema(schemaCache, definitions, entry) {
     return toLocalizedArray(entry)
   }
 
-  const schema = addAnnotations(entry, primitiveElementToSchema(entry))
+  const schema = addAnnotations(entry, primitiveElementToSchema(entry), i18nBundle)
 
   if (schemaUtils.isDefault(entry)) {
     schemaUtils.addDefaultValue(entry, schema)
@@ -112,7 +112,7 @@ function elementToSchema(schemaCache, definitions, entry) {
   return schema
 }
 
-function associationToSchema(schemaCache, definitions, entry) {
+function associationToSchema(schemaCache, definitions, entry, i18nBundle) {
   let associationTargetDefinition = JSON.parse(JSON.stringify(definitions[entry.target]))
   Object.keys(associationTargetDefinition.elements).forEach(element => {
     if (associationTargetDefinition.elements[element].key === undefined) {
@@ -121,26 +121,27 @@ function associationToSchema(schemaCache, definitions, entry) {
   })
 
   if (schemaUtils.isToManyAssociation(entry)) {
-    return getArrayOfType(elementsToSchema(schemaCache, definitions, associationTargetDefinition))
+    return getArrayOfType(elementsToSchema(schemaCache, definitions, associationTargetDefinition, undefined, i18nBundle))
   } else {
-    return elementsToSchema(schemaCache, definitions, associationTargetDefinition)
+    return elementsToSchema(schemaCache, definitions, associationTargetDefinition, undefined, i18nBundle)
   }
 }
 
-function manyToSchema(schemaCache, definitions, entry) {
+function manyToSchema(schemaCache, definitions, entry, i18nBundle) {
   return getArrayOfType(
     schemaUtils.isStructured(entry.items)
-      ? elementsToSchema(schemaCache, definitions, entry.items)
+      ? elementsToSchema(schemaCache, definitions, entry.items, undefined, i18nBundle)
       : elementToSchema(schemaCache, definitions,
           // if entry.items.type can be found at definitions, it is a reuse type
-          definitions[entry.items.type] ? definitions[entry.items.type] : (entry.items)
+          definitions[entry.items.type] ? definitions[entry.items.type] : (entry.items),
+          i18nBundle
         )
   )
 }
 
-function compositionToSchema(schemaCache, definitions, entry) {
+function compositionToSchema(schemaCache, definitions, entry, i18nBundle) {
   if (schemaUtils.isStructured(entry.targetAspect)) {
-    const objectType = elementsToSchema(schemaCache, definitions, entry.targetAspect)
+    const objectType = elementsToSchema(schemaCache, definitions, entry.targetAspect, undefined, i18nBundle)
     return schemaUtils.isToMany(entry) ? getArrayOfType(objectType) : objectType
   }
   // Composition of aspects might have a target towards a generated entity
@@ -157,9 +158,9 @@ function compositionToSchema(schemaCache, definitions, entry) {
 
   let objectType
   if (schemaUtils.isStructured(definitions[target])) {
-    objectType = elementsToSchema(schemaCache, definitions, definitions[target])
+    objectType = elementsToSchema(schemaCache, definitions, definitions[target], undefined, i18nBundle)
   } else {
-    objectType = elementToSchema(schemaCache, definitions, target)
+    objectType = elementToSchema(schemaCache, definitions, target, i18nBundle)
   }
 
   return cacheAndReturn(schemaCache, cacheKey,
@@ -167,7 +168,7 @@ function compositionToSchema(schemaCache, definitions, entry) {
   )
 }
 
-function refToSchema(schemaCache, definitions, entry) {
+function refToSchema(schemaCache, definitions, entry, i18nBundle) {
   const refKey = entry.type.ref.join('.')
 
   if (schemaCache[refKey]) {
@@ -177,7 +178,7 @@ function refToSchema(schemaCache, definitions, entry) {
   return cacheAndReturn(
     schemaCache,
     refKey,
-    elementToSchema(schemaCache, definitions, followRefRecursive(definitions, entry.type))
+    elementToSchema(schemaCache, definitions, followRefRecursive(definitions, entry.type), i18nBundle)
   )
 }
 

--- a/lib/compile/components/schemas/definition.js
+++ b/lib/compile/components/schemas/definition.js
@@ -20,7 +20,7 @@ function definitionToSchema(eventDefinition, definitions, schemaCache, i18nBundl
 
 function elementsToSchema(schemaCache, definitions, entry, nullable, i18nBundle) {
   if (!schemaUtils.isStructured(entry)) {
-    return elementToSchema(schemaCache, definitions, entry, i18nBundle, nullable)
+    return elementToSchema(schemaCache, definitions, entry, i18nBundle)
   }
 
   const required = []

--- a/lib/compile/components/schemas/index.js
+++ b/lib/compile/components/schemas/index.js
@@ -1,13 +1,13 @@
 const { definitionToSchema } = require('./definition')
 const { getEventName } = require('../../utils')
 
-module.exports = function csnToJSONSchema(definitions, events) {
+module.exports = function csnToJSONSchema(definitions, events, i18nBundle) {
     let schemaCache = {}
     let schema = {}
 
     events.forEach(event => {
         const eventName = getEventName(event, definitions[event])
-        schema[eventName] = definitionToSchema(event, definitions, schemaCache)
+        schema[eventName] = definitionToSchema(event, definitions, schemaCache, i18nBundle)
     })
 
     return schema

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -14,7 +14,15 @@ const presetMapping = {
 }
 
 module.exports = function processor(csn, options = {}) {
-    const i18nBundle = cds.i18n.bundle4(csn)
+    // Derive i18n bundle from CSN - uses the CSN's $sources to find i18n files
+    let i18nBundle
+    try {
+        i18nBundle = cds.i18n.bundle4(csn)
+    } catch (e) {
+        // If bundle creation fails, continue without i18n support
+        DEBUG?.('i18n bundle creation failed:', e.message)
+        i18nBundle = null
+    }
 
     let envConf = {}
     if (cds.env?.export?.asyncapi) {

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -10,7 +10,8 @@ const presetMapping = {
     'event_spec_version': 'x-sap-event-spec-version',
     'event_source': 'x-sap-event-source',
     'event_source_params': 'x-sap-event-source-parameters',
-    'event_characteristics': 'x-sap-event-characteristics'
+    'event_characteristics': 'x-sap-event-characteristics',
+    'cloudevents_examples': 'cloudevents_examples'
 }
 
 module.exports = function processor(csn, options = {}) {
@@ -236,7 +237,7 @@ function getServicesWithEvents(definitions) {
 function getComponents(definitions, events, presets, i18nBundle) {
 
     return {
-        messageTraits: getMessageTraits(),
+        messageTraits: getMessageTraits(presets),
         messages: definitionsToMessages(definitions, events, presets, i18nBundle),
         schemas: csnToJSONSchema(definitions, events, i18nBundle)
     }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -237,7 +237,7 @@ function getComponents(definitions, events, presets, i18nBundle) {
 
     return {
         messageTraits: getMessageTraits(),
-        messages: definitionsToMessages(definitions, events, presets),
+        messages: definitionsToMessages(definitions, events, presets, i18nBundle),
         schemas: csnToJSONSchema(definitions, events, i18nBundle)
     }
 }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -14,11 +14,12 @@ const presetMapping = {
 }
 
 module.exports = function processor(csn, options = {}) {
+    const i18nBundle = cds.i18n.bundle4(csn)
 
     let envConf = {}
     if (cds.env?.export?.asyncapi) {
         envConf = cds.env.export.asyncapi
-    } 
+    }
     if (!cds.env?.export?.asyncapi?.application_namespace) {
         const packageJson = require(join(cds.root,'package.json'))
         const appName = packageJson.name.replace(/^[@]/, '').replace(/[@/]/g, '-')
@@ -61,11 +62,11 @@ module.exports = function processor(csn, options = {}) {
                 info: infoObject,
                 defaultContentType: 'application/json',
                 channels: getChannels(csn.definitions, events),
-                components: getComponents(csn.definitions, events, presets)
+                components: getComponents(csn.definitions, events, presets, i18nBundle)
             }
         } else {
             const services  = getServicesWithEvents(csn.definitions)
-            return _iterate(services, csn, applicationNamespace, presets)
+            return _iterate(services, csn, applicationNamespace, presets, i18nBundle)
         }
     } else {
         const events = getEvents(csn.definitions, options.service)
@@ -74,7 +75,7 @@ module.exports = function processor(csn, options = {}) {
             throw new Error(messages.NO_EVENTS)
         }
 
-        return _getAsyncApi(csn, events, options.service, applicationNamespace, presets)
+        return _getAsyncApi(csn, events, options.service, applicationNamespace, presets, i18nBundle)
     }
 }
 
@@ -86,7 +87,7 @@ function getPresets(envConf) {
     return projectPresets
 }
 
-function _getAsyncApi(csn, events, serviceName, applicationNamespace, presets) {
+function _getAsyncApi(csn, events, serviceName, applicationNamespace, presets, i18nBundle) {
 
     const infoObject = getInfoObject(csn.definitions[serviceName])
     const stateObj = getStateInfo(csn.definitions[serviceName])
@@ -102,7 +103,7 @@ function _getAsyncApi(csn, events, serviceName, applicationNamespace, presets) {
         info: infoObject,
         defaultContentType: 'application/json',
         channels: getChannels(csn.definitions, events),
-        components: getComponents(csn.definitions, events, presets)
+        components: getComponents(csn.definitions, events, presets, i18nBundle)
     }
 }
 
@@ -224,12 +225,12 @@ function getServicesWithEvents(definitions) {
     return services
 }
 
-function getComponents(definitions, events, presets) {
+function getComponents(definitions, events, presets, i18nBundle) {
 
     return {
         messageTraits: getMessageTraits(),
         messages: definitionsToMessages(definitions, events, presets),
-        schemas: csnToJSONSchema(definitions, events)
+        schemas: csnToJSONSchema(definitions, events, i18nBundle)
     }
 }
 
@@ -256,9 +257,9 @@ function _serviceErrorHandling(csn, options) {
     }
 }
 
-function* _iterate(services, csn, applicationNamespace, presets) {
+function* _iterate(services, csn, applicationNamespace, presets, i18nBundle) {
     for (const [key, value] of Object.entries(services)) {
-        const generatedAsyncAPI = _getAsyncApi(csn, value.events, key, applicationNamespace, presets)
+        const generatedAsyncAPI = _getAsyncApi(csn, value.events, key, applicationNamespace, presets, i18nBundle)
         yield [generatedAsyncAPI, { file: key }]
     }
 }

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -38,8 +38,29 @@ function resolveI18n(text, i18nBundle) {
     return i18nBundle?.at(match[1]) ?? text
 }
 
+/**
+ * Extracts description from definition with fallback chain:
+ * 1. @description annotation (with i18n resolution)
+ * 2. @Core.Description annotation (with i18n resolution)
+ * 3. doc comment (plain text)
+ * @param {object} definition - Event or element definition from CSN
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string|undefined} Description text or undefined if none found
+ */
+function getDescription(definition, i18nBundle) {
+    if (typeof definition['@description'] === 'string') {
+        return resolveI18n(definition['@description'], i18nBundle)
+    } else if (typeof definition['@Core.Description'] === 'string') {
+        return resolveI18n(definition['@Core.Description'], i18nBundle)
+    } else if (typeof definition.doc === 'string') {
+        return definition.doc.replace(/\n/g, ' ')
+    }
+    return undefined
+}
+
 module.exports = {
     getEventName,
     getOwnValue,
-    resolveI18n
+    resolveI18n,
+    getDescription
 }

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -21,7 +21,25 @@ function getOwnValue(entry, key) {
     return
 }
 
+/**
+ * Resolves i18n markers in a string like '{i18n>KEY}' using the provided i18n bundle
+ * @param {string} text
+ * @param {object} i18nBundle - CDS i18n bundle from cds.i18n.bundle4(csn)
+ * @return {string} Resolved text if it contained an i18n marker, otherwise the original text
+ */
+function resolveI18n(text, i18nBundle) {
+    if (typeof text !== 'string' || !text.includes('{i18n>')) {
+        return text
+    }
+    const match = text.match(/\{i18n>([^}]+)\}/)
+    if (!match) {
+        return text
+    }
+    return i18nBundle?.at(match[1]) ?? text
+}
+
 module.exports = {
     getEventName,
-    getOwnValue
+    getOwnValue,
+    resolveI18n
 }

--- a/test/lib/compile/asyncapiMetadata.test.js
+++ b/test/lib/compile/asyncapiMetadata.test.js
@@ -106,4 +106,22 @@ describe('asyncapi export: presets and annotations', () => {
         assert.ok(!('console' in generatedAsyncAPI))
         assert.ok(!generatedAsyncAPI.console)
     })
+
+    test('CloudEvents header examples can be customized', async () => {
+        const inputCDS = await read(join(baseInputPath, 'valid', 'cloudevents-custom-examples.cds'))
+        cds.env.export.asyncapi = {
+            application_namespace: 'com.example.project',
+            cloudevents_examples: {
+                type: ['com.example.project.IssueCreated.v1', 'com.example.project.IssueUpdated.v1'],
+                source: ['/prod/project-mgmt/instance-001'],
+                subject: ['issue-12345', 'issue-67890'],
+                dataschema: ['https://api.example.com/schemas/IssueCreated/v1.0']
+            }
+        }
+        const csn = cds.compile.to.csn(inputCDS)
+        const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'cloudevents-custom-examples.json')))
+        const generatedAsyncAPI = toAsyncAPI(csn)
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
+    })
 })
+

--- a/test/lib/compile/asyncapiOptions.test.js
+++ b/test/lib/compile/asyncapiOptions.test.js
@@ -72,7 +72,7 @@ describe('asyncapi export: options', () => {
     for (const [, metadata] of generatedAsyncAPI) {
       filesFound.add(metadata.file)
     }
-    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S']))
+    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S', 'com.example.project.ProjectService']))
   })
 
   test('Merged flag throws an error if title and version are not specified', async () => {

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -80,4 +80,8 @@ describe('asyncapi export: to json schema', () => {
     await compileAndCheck('descriptions.cds', 'descriptions.json')
   })
 
+  test('Test for i18n in Descriptions', async () => {
+    await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+  })
+
 })

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -10,7 +10,7 @@ const baseOutputPath = join(__dirname, 'output')
 async function compileAndCheck(inputFile, outputFile) {
   const inputCDS = await read(join(baseInputPath, inputFile))
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
-  const csn = cds.compile.to.csn(inputCDS)
+  const csn = cds.compile.to.csn(inputCDS, { docs: true })
   const generatedAsyncAPI = toAsyncAPI(csn)
   assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
 }

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -76,7 +76,7 @@ describe('asyncapi export: to json schema', () => {
     await compileAndCheck('unManagedComposition.cds', 'unManagedComposition.json')
   })
 
-  test('Test for Description Annotations', async () => {
+  test('Test for @Core.Description annotation as fallback to @description', async () => {
     await compileAndCheck('descriptions.cds', 'descriptions.json')
   })
 

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -8,9 +8,25 @@ const baseInputPath = join(__dirname, 'input')
 const baseOutputPath = join(__dirname, 'output')
 
 async function compileAndCheck(inputFile, outputFile) {
-  const inputCDS = await read(join(baseInputPath, inputFile))
+  const inputPath = join(baseInputPath, inputFile)
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
+  
+  // Compile from string to preserve doc comments
+  const inputCDS = await read(inputPath)
   const csn = cds.compile.to.csn(inputCDS, { docs: true })
+  
+  const generatedAsyncAPI = toAsyncAPI(csn)
+  assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
+}
+
+async function compileAndCheckWithI18n(inputFile, outputFile) {
+  const inputPath = join(baseInputPath, inputFile)
+  const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
+  
+  // Load from file path to get i18n files
+  const model = await cds.load(inputPath)
+  const csn = cds.compile.to.csn(model, { docs: true })
+  
   const generatedAsyncAPI = toAsyncAPI(csn)
   assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
 }
@@ -85,7 +101,7 @@ describe('asyncapi export: to json schema', () => {
     const originalRoot = cds.root
     try {
       cds.root = baseInputPath
-      await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+      await compileAndCheckWithI18n('i18n-descriptions.cds', 'i18n-descriptions.json')
     } finally {
       cds.root = originalRoot
     }

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -74,4 +74,8 @@ describe('asyncapi export: to json schema', () => {
     await compileAndCheck('unManagedComposition.cds', 'unManagedComposition.json');
   });
 
+  test("Test for Description Annotations", async () => {
+    await compileAndCheck('descriptions.cds', 'descriptions.json');
+  });
+
 });

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -10,11 +10,11 @@ const baseOutputPath = join(__dirname, 'output')
 async function compileAndCheck(inputFile, outputFile) {
   const inputPath = join(baseInputPath, inputFile)
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
-  
+
   // Compile from string to preserve doc comments
   const inputCDS = await read(inputPath)
   const csn = cds.compile.to.csn(inputCDS, { docs: true })
-  
+
   const generatedAsyncAPI = toAsyncAPI(csn)
   assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
 }
@@ -22,11 +22,11 @@ async function compileAndCheck(inputFile, outputFile) {
 async function compileAndCheckWithI18n(inputFile, outputFile) {
   const inputPath = join(baseInputPath, inputFile)
   const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, outputFile)))
-  
+
   // Load from file path to get i18n files
   const model = await cds.load(inputPath)
   const csn = cds.compile.to.csn(model, { docs: true })
-  
+
   const generatedAsyncAPI = toAsyncAPI(csn)
   assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
 }

--- a/test/lib/compile/components/schemas/csnToJSONSchema.test.js
+++ b/test/lib/compile/components/schemas/csnToJSONSchema.test.js
@@ -81,7 +81,14 @@ describe('asyncapi export: to json schema', () => {
   })
 
   test('Test for i18n in Descriptions', async () => {
-    await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+    // Save original cds.root and set to input directory so CDS can find i18n files
+    const originalRoot = cds.root
+    try {
+      cds.root = baseInputPath
+      await compileAndCheck('i18n-descriptions.cds', 'i18n-descriptions.json')
+    } finally {
+      cds.root = originalRoot
+    }
   })
 
 })

--- a/test/lib/compile/components/schemas/input/_i18n/i18n.properties
+++ b/test/lib/compile/components/schemas/input/_i18n/i18n.properties
@@ -1,0 +1,4 @@
+FIELD_DESC = Field description from i18n
+CORE_FIELD_DESC = Core field description from i18n
+EVENT_DESC = Event description from i18n
+PRODUCT_ID = Product identifier

--- a/test/lib/compile/components/schemas/input/descriptions.cds
+++ b/test/lib/compile/components/schemas/input/descriptions.cds
@@ -14,6 +14,9 @@ service MyService {
     @Core.Description: 'This is ignored'
     fieldWithBoth: String;
 
+    /** Doc comment as fallback */
+    fieldWithDocComment: String;
+
     fieldWithoutDescription: String;
   };
 }

--- a/test/lib/compile/components/schemas/input/descriptions.cds
+++ b/test/lib/compile/components/schemas/input/descriptions.cds
@@ -1,0 +1,19 @@
+namespace com.sap.test;
+
+@AsyncAPI.Title        : 'Description Test Service'
+@AsyncAPI.SchemaVersion: '1.0.0'
+service MyService {
+  event TestEvent : {
+    @description: 'Field with standard description annotation'
+    fieldWithDescription: String;
+
+    @Core.Description: 'Field with Core.Description annotation'
+    fieldWithCoreDescription: String;
+
+    @description: 'This takes priority'
+    @Core.Description: 'This is ignored'
+    fieldWithBoth: String;
+
+    fieldWithoutDescription: String;
+  };
+}

--- a/test/lib/compile/components/schemas/input/descriptions.cds
+++ b/test/lib/compile/components/schemas/input/descriptions.cds
@@ -3,6 +3,14 @@ namespace com.sap.test;
 @AsyncAPI.Title        : 'Description Test Service'
 @AsyncAPI.SchemaVersion: '1.0.0'
 service MyService {
+  @Core.Description: 'Event with @Core.Description annotation'
+  event Foo {}
+  @description: 'This takes priority'
+  @Core.Description: 'This is ignored'
+  event Bar {}
+  /** Doc comment as fallback */
+  event Baz {}
+
   event TestEvent : {
     @description: 'Field with standard description annotation'
     fieldWithDescription: String;

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -9,11 +9,11 @@ service MyService {
 
     @Core.Description: '{i18n>CORE_FIELD_DESC}'
     fieldWithCoreI18n: String;
-    
+
     @description: 'Plain text description'
     fieldWithPlainText: String;
   };
-  
+
   @Core.Description: '{i18n>EVENT_DESC}'
   event I18nEvent : {
     @description: '{i18n>PRODUCT_ID}'

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -1,0 +1,22 @@
+namespace com.sap.test;
+
+@AsyncAPI.Title        : 'i18n Test Service'
+@AsyncAPI.SchemaVersion: '1.0.0'
+service MyService {
+  event TestEvent : {
+    @description: '{i18n>FIELD_DESC}'
+    fieldWithI18n: String;
+
+    @Core.Description: '{i18n>CORE_FIELD_DESC}'
+    fieldWithCoreI18n: String;
+    
+    @description: 'Plain text description'
+    fieldWithPlainText: String;
+  };
+  
+  @Core.Description: '{i18n>EVENT_DESC}'
+  event I18nEvent : {
+    @description: '{i18n>PRODUCT_ID}'
+    productId: String;
+  };
+}

--- a/test/lib/compile/components/schemas/input/i18n-descriptions.cds
+++ b/test/lib/compile/components/schemas/input/i18n-descriptions.cds
@@ -3,6 +3,7 @@ namespace com.sap.test;
 @AsyncAPI.Title        : 'i18n Test Service'
 @AsyncAPI.SchemaVersion: '1.0.0'
 service MyService {
+
   event TestEvent : {
     @description: '{i18n>FIELD_DESC}'
     fieldWithI18n: String;

--- a/test/lib/compile/components/schemas/output/descriptions.json
+++ b/test/lib/compile/components/schemas/output/descriptions.json
@@ -1,0 +1,168 @@
+{
+  "asyncapi": "2.0.0",
+  "x-sap-catalog-spec-version": "1.2",
+  "x-sap-application-namespace": "com.sap.test",
+  "info": {
+    "version": "1.0.0",
+    "title": "Description Test Service"
+  },
+  "defaultContentType": "application/json",
+  "channels": {
+    "com.sap.test.MyService.TestEvent": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.TestEvent"
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "CloudEventsContext.v1": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Identifies the event.",
+              "type": "string",
+              "examples": [
+                "6925d08e-bc19-4ad7-902e-bd29721cc69b"
+              ]
+            },
+            "specversion": {
+              "description": "The version of the CloudEvents specification which the event uses.",
+              "type": "string",
+              "const": "1.0"
+            },
+            "source": {
+              "description": "Identifies the instance the event originated in.",
+              "type": "string",
+              "format": "uri-reference",
+              "examples": [
+                "/default/sap.s4.beh/ER9CLNT001",
+                "/eu/sap.billing.sb/91dec60d-9757-4e2c-b9e5-21da10016fe9"
+              ]
+            },
+            "type": {
+              "description": "Describes the type of the event related to the source the event originated in.",
+              "type": "string",
+              "examples": [
+                "sap.dsc.FreightOrder.Arrived.v1",
+                "sap.billing.sb.Subscription.Canceled.v1"
+              ]
+            },
+            "subject": {
+              "description": "Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).",
+              "type": "string",
+              "examples": [
+                "ce307052-75a0-4a8f-a961-ebf21669bb80",
+                "urn:epc:tag:sgtin-96:1.7332402.026591.1234567890"
+              ]
+            },
+            "datacontenttype": {
+              "description": "Content type of the event data.",
+              "type": "string",
+              "const": "application/json"
+            },
+            "dataschema": {
+              "description": "Identifies the schema that the event data adheres to.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "http://example.com/event/sap.billing.sb.Subscription.Canceled/v1.2.0"
+              ]
+            },
+            "time": {
+              "description": "Timestamp of when the occurrence happened.",
+              "format": "date-time",
+              "type": "string",
+              "examples": [
+                "2018-04-05T17:31:00Z"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "source",
+            "specversion",
+            "type"
+          ],
+          "patternProperties": {
+            "^xsap[a-z0-9]+$": {
+              "description": "Application defined custom extension context attributes.",
+              "type": [
+                "boolean",
+                "integer",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "messages": {
+      "com.sap.test.MyService.TestEvent": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.TestEvent",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.TestEvent"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.TestEvent"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      }
+    },
+    "schemas": {
+      "com.sap.test.MyService.TestEvent": {
+        "type": "object",
+        "properties": {
+          "fieldWithDescription": {
+            "type": "string",
+            "description": "Field with standard description annotation"
+          },
+          "fieldWithCoreDescription": {
+            "type": "string",
+            "description": "Field with Core.Description annotation"
+          },
+          "fieldWithBoth": {
+            "type": "string",
+            "description": "This takes priority"
+          },
+          "fieldWithoutDescription": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/lib/compile/components/schemas/output/descriptions.json
+++ b/test/lib/compile/components/schemas/output/descriptions.json
@@ -8,6 +8,27 @@
   },
   "defaultContentType": "application/json",
   "channels": {
+    "com.sap.test.MyService.Foo": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.Foo"
+        }
+      }
+    },
+    "com.sap.test.MyService.Bar": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.Bar"
+        }
+      }
+    },
+    "com.sap.test.MyService.Baz": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.Baz"
+        }
+      }
+    },
     "com.sap.test.MyService.TestEvent": {
       "subscribe": {
         "message": {
@@ -101,6 +122,126 @@
       }
     },
     "messages": {
+      "com.sap.test.MyService.Foo": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.Foo",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.Foo"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.Foo"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "com.sap.test.MyService.Bar": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.Bar",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.Bar"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.Bar"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "com.sap.test.MyService.Baz": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.Baz",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.Baz"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.Baz"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
       "com.sap.test.MyService.TestEvent": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
         "x-sap-event-source-parameters": {
@@ -143,6 +284,18 @@
       }
     },
     "schemas": {
+      "com.sap.test.MyService.Foo": {
+        "description": "Event with @Core.Description annotation",
+        "type": "object"
+      },
+      "com.sap.test.MyService.Bar": {
+        "description": "This takes priority",
+        "type": "object"
+      },
+      "com.sap.test.MyService.Baz": {
+        "description": "Doc comment as fallback",
+        "type": "object"
+      },
       "com.sap.test.MyService.TestEvent": {
         "type": "object",
         "properties": {

--- a/test/lib/compile/components/schemas/output/descriptions.json
+++ b/test/lib/compile/components/schemas/output/descriptions.json
@@ -158,6 +158,10 @@
             "type": "string",
             "description": "This takes priority"
           },
+          "fieldWithDocComment": {
+            "type": "string",
+            "description": "Doc comment as fallback"
+          },
           "fieldWithoutDescription": {
             "type": "string"
           }

--- a/test/lib/compile/components/schemas/output/descriptions.json
+++ b/test/lib/compile/components/schemas/output/descriptions.json
@@ -160,7 +160,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Event with @Core.Description annotation"
       },
       "com.sap.test.MyService.Bar": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
@@ -200,7 +201,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "This takes priority"
       },
       "com.sap.test.MyService.Baz": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
@@ -240,7 +242,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Doc comment as fallback"
       },
       "com.sap.test.MyService.TestEvent": {
         "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",

--- a/test/lib/compile/components/schemas/output/i18n-descriptions.json
+++ b/test/lib/compile/components/schemas/output/i18n-descriptions.json
@@ -186,7 +186,8 @@
           {
             "$ref": "#/components/messageTraits/CloudEventsContext.v1"
           }
-        ]
+        ],
+        "description": "Event description from i18n"
       }
     },
     "schemas": {

--- a/test/lib/compile/components/schemas/output/i18n-descriptions.json
+++ b/test/lib/compile/components/schemas/output/i18n-descriptions.json
@@ -1,0 +1,222 @@
+{
+  "asyncapi": "2.0.0",
+  "x-sap-catalog-spec-version": "1.2",
+  "x-sap-application-namespace": "com.sap.test",
+  "info": {
+    "version": "1.0.0",
+    "title": "i18n Test Service"
+  },
+  "defaultContentType": "application/json",
+  "channels": {
+    "com.sap.test.MyService.TestEvent": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.TestEvent"
+        }
+      }
+    },
+    "com.sap.test.MyService.I18nEvent": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.test.MyService.I18nEvent"
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "CloudEventsContext.v1": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Identifies the event.",
+              "type": "string",
+              "examples": [
+                "6925d08e-bc19-4ad7-902e-bd29721cc69b"
+              ]
+            },
+            "specversion": {
+              "description": "The version of the CloudEvents specification which the event uses.",
+              "type": "string",
+              "const": "1.0"
+            },
+            "source": {
+              "description": "Identifies the instance the event originated in.",
+              "type": "string",
+              "format": "uri-reference",
+              "examples": [
+                "/default/sap.s4.beh/ER9CLNT001",
+                "/eu/sap.billing.sb/91dec60d-9757-4e2c-b9e5-21da10016fe9"
+              ]
+            },
+            "type": {
+              "description": "Describes the type of the event related to the source the event originated in.",
+              "type": "string",
+              "examples": [
+                "sap.dsc.FreightOrder.Arrived.v1",
+                "sap.billing.sb.Subscription.Canceled.v1"
+              ]
+            },
+            "subject": {
+              "description": "Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).",
+              "type": "string",
+              "examples": [
+                "ce307052-75a0-4a8f-a961-ebf21669bb80",
+                "urn:epc:tag:sgtin-96:1.7332402.026591.1234567890"
+              ]
+            },
+            "datacontenttype": {
+              "description": "Content type of the event data.",
+              "type": "string",
+              "const": "application/json"
+            },
+            "dataschema": {
+              "description": "Identifies the schema that the event data adheres to.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "http://example.com/event/sap.billing.sb.Subscription.Canceled/v1.2.0"
+              ]
+            },
+            "time": {
+              "description": "Timestamp of when the occurrence happened.",
+              "format": "date-time",
+              "type": "string",
+              "examples": [
+                "2018-04-05T17:31:00Z"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "source",
+            "specversion",
+            "type"
+          ],
+          "patternProperties": {
+            "^xsap[a-z0-9]+$": {
+              "description": "Application defined custom extension context attributes.",
+              "type": [
+                "boolean",
+                "integer",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "messages": {
+      "com.sap.test.MyService.TestEvent": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.TestEvent",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.TestEvent"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.TestEvent"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "com.sap.test.MyService.I18nEvent": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.test.MyService.I18nEvent",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.test.MyService.I18nEvent"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.test.MyService.I18nEvent"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      }
+    },
+    "schemas": {
+      "com.sap.test.MyService.TestEvent": {
+        "type": "object",
+        "properties": {
+          "fieldWithI18n": {
+            "type": "string",
+            "description": "Field description from i18n"
+          },
+          "fieldWithCoreI18n": {
+            "type": "string",
+            "description": "Core field description from i18n"
+          },
+          "fieldWithPlainText": {
+            "type": "string",
+            "description": "Plain text description"
+          }
+        }
+      },
+      "com.sap.test.MyService.I18nEvent": {
+        "type": "object",
+        "properties": {
+          "productId": {
+            "type": "string",
+            "description": "Product identifier"
+          }
+        },
+        "description": "Event description from i18n"
+      }
+    }
+  }
+}

--- a/test/lib/compile/input/valid/cloudevents-custom-examples.cds
+++ b/test/lib/compile/input/valid/cloudevents-custom-examples.cds
@@ -1,0 +1,10 @@
+namespace com.example.project;
+
+@AsyncAPI.Title        : 'Project Management Service'
+@AsyncAPI.SchemaVersion: '1.0.0'
+service ProjectService {
+    event IssueCreated : {
+        issueId: String;
+        title: String;
+    };
+}

--- a/test/lib/compile/output/cloudevents-custom-examples.json
+++ b/test/lib/compile/output/cloudevents-custom-examples.json
@@ -1,0 +1,174 @@
+{
+  "asyncapi": "2.0.0",
+  "x-sap-catalog-spec-version": "1.2",
+  "x-sap-application-namespace": "com.example.project",
+  "info": {
+    "version": "1.0.0",
+    "title": "Project Management Service"
+  },
+  "defaultContentType": "application/json",
+  "channels": {
+    "com.example.project.ProjectService.IssueCreated": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.example.project.ProjectService.IssueCreated"
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "CloudEventsContext.v1": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Identifies the event.",
+              "type": "string",
+              "examples": [
+                "6925d08e-bc19-4ad7-902e-bd29721cc69b"
+              ]
+            },
+            "specversion": {
+              "description": "The version of the CloudEvents specification which the event uses.",
+              "type": "string",
+              "const": "1.0"
+            },
+            "source": {
+              "description": "Identifies the instance the event originated in.",
+              "type": "string",
+              "format": "uri-reference",
+              "examples": [
+                "/prod/project-mgmt/instance-001"
+              ]
+            },
+            "type": {
+              "description": "Describes the type of the event related to the source the event originated in.",
+              "type": "string",
+              "examples": [
+                "com.example.project.IssueCreated.v1",
+                "com.example.project.IssueUpdated.v1"
+              ]
+            },
+            "subject": {
+              "description": "Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).",
+              "type": "string",
+              "examples": [
+                "issue-12345",
+                "issue-67890"
+              ]
+            },
+            "datacontenttype": {
+              "description": "Content type of the event data.",
+              "type": "string",
+              "const": "application/json"
+            },
+            "dataschema": {
+              "description": "Identifies the schema that the event data adheres to.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "https://api.example.com/schemas/IssueCreated/v1.0"
+              ]
+            },
+            "time": {
+              "description": "Timestamp of when the occurrence happened.",
+              "format": "date-time",
+              "type": "string",
+              "examples": [
+                "2018-04-05T17:31:00Z"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "source",
+            "specversion",
+            "type"
+          ],
+          "patternProperties": {
+            "^xsap[a-z0-9]+$": {
+              "description": "Application defined custom extension context attributes.",
+              "type": [
+                "boolean",
+                "integer",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "messages": {
+      "com.example.project.ProjectService.IssueCreated": {
+        "cloudevents_examples": {
+          "type": [
+            "com.example.project.IssueCreated.v1",
+            "com.example.project.IssueUpdated.v1"
+          ],
+          "source": [
+            "/prod/project-mgmt/instance-001"
+          ],
+          "subject": [
+            "issue-12345",
+            "issue-67890"
+          ],
+          "dataschema": [
+            "https://api.example.com/schemas/IssueCreated/v1.0"
+          ]
+        },
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.example.project.ProjectService.IssueCreated",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.example.project.ProjectService.IssueCreated"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.example.project.ProjectService.IssueCreated"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      }
+    },
+    "schemas": {
+      "com.example.project.ProjectService.IssueCreated": {
+        "type": "object",
+        "properties": {
+          "issueId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Support `@Core.Description` Annotation and i18n Resolution in AsyncAPI Export

### New Features

✨ This PR introduces several enhancements to the AsyncAPI export functionality:

- **`@Core.Description` support**: The `@Core.Description` annotation is now recognized as a fallback for descriptions when `@description` is not present. Priority order: `@description` → `@Core.Description` → doc comment.
- **Automatic i18n resolution**: Description strings and titles containing i18n markers (e.g., `{i18n>KEY}`) are now automatically resolved using CDS i18n bundles derived from the CSN's source files.
- **Event descriptions in messages**: Event descriptions now also appear in `components.messages.<event>.description` in addition to `components.schemas.<event>.description`.
- **Customizable CloudEvents header examples**: CloudEvents header examples (`source`, `type`, `subject`, `dataschema`) can now be overridden via `cds.env.export.asyncapi.cloudevents_examples` configuration.

### Changes

* `lib/compile/utils.js`: Added two new utility functions — `resolveI18n()` to resolve `{i18n>KEY}` markers using a CDS i18n bundle, and `getDescription()` implementing the fallback chain for description extraction.
* `lib/compile/index.js`: Integrated i18n bundle derivation at the processor entry point; propagated `i18nBundle` and `presets` (including `cloudevents_examples`) throughout the call chain; fixed `getMessageTraits()` to receive presets.
* `lib/compile/components/schemas/annotations.js`: Replaced inline description/title logic with calls to `getDescription()` and `resolveI18n()`; `addAnnotations()` now accepts and forwards `i18nBundle`.
* `lib/compile/components/schemas/definition.js`: Propagated `i18nBundle` through all schema conversion functions.
* `lib/compile/components/schemas/index.js`: `csnToJSONSchema()` now accepts and passes `i18nBundle`.
* `lib/compile/components/messages/index.js`: `eventToMessage()` now resolves and sets `description` on message objects; `i18nBundle` propagated through all message functions.
* `lib/compile/components/messageTraits/index.js`: `getMessageTraits()` now accepts `presets` and uses `customExamples` to override CloudEvents header examples for `source`, `type`, `subject`, and `dataschema` fields.
* `test/lib/compile/components/schemas/input/descriptions.cds`: New test CDS model covering `@Core.Description`, `@description` priority, and doc comment fallback scenarios.
* `test/lib/compile/components/schemas/input/i18n-descriptions.cds`: New test model for i18n marker resolution in descriptions.
* `test/lib/compile/components/schemas/input/_i18n/i18n.properties`: i18n properties file for test fixtures.
* `test/lib/compile/components/schemas/output/descriptions.json`, `i18n-descriptions.json`: Expected output snapshots for new test cases.
* `test/lib/compile/input/valid/cloudevents-custom-examples.cds` + `test/lib/compile/output/cloudevents-custom-examples.json`: Test fixture for customizable CloudEvents examples.
* `test/lib/compile/asyncapiMetadata.test.js`: Added test for customizable CloudEvents header examples.
* `test/lib/compile/components/schemas/csnToJSONSchema.test.js`: Added tests for `@Core.Description` fallback and i18n resolution; updated compile helper to enable `docs` mode.
* `CHANGELOG.md`: Documented all new features under `[Unreleased]`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Correlation ID: `7aa4f56b-ea7b-483d-9148-67121d066b9e`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
