### PR TITLE
Introduce ChannelName annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+- Support for `@AsyncAPI.ChannelName` annotation to allow custom channel names independent of message/schema references (enables channel names with special characters like slashes)
 - Support for `@Core.Description` annotation as an alternative to `@description`
 - Automatic resolution of i18n markers (e.g., `{i18n>KEY}`)
 

--- a/lib/compile/channels.js
+++ b/lib/compile/channels.js
@@ -1,4 +1,4 @@
-const { getEventName } = require('./utils')
+const { getEventName, getChannelName } = require('./utils')
 
 function getChannel(eventName) {
     return {
@@ -15,7 +15,8 @@ module.exports = function getChannels(definitions, events) {
 
     events.forEach(event => {
         let eventName = getEventName(event, definitions[event])
-        channels[eventName] = getChannel(eventName)
+        let channelName = getChannelName(event, definitions[event]) || eventName
+        channels[channelName] = getChannel(eventName)
     })
 
     return channels

--- a/lib/compile/channels.js
+++ b/lib/compile/channels.js
@@ -1,23 +1,18 @@
 const { getEventName, getChannelName } = require('./utils')
 
-function getChannel(eventName) {
-    return {
-        subscribe: {
-            message: {
-                $ref: '#/components/messages/' + eventName
-            }
+const getChannel = eventName => ({
+    subscribe: {
+        message: {
+            $ref: '#/components/messages/' + eventName
         }
     }
-}
+})
 
-module.exports = function getChannels(definitions, events) {
-    let channels = {}
-
-    events.forEach(event => {
-        let eventName = getEventName(event, definitions[event])
-        let channelName = getChannelName(event, definitions[event]) || eventName
-        channels[channelName] = getChannel(eventName)
-    })
-
+const getChannels = (definitions, events) => events.reduce((channels, event) => {
+    const eventName = getEventName(event, definitions[event])
+    const channelName = getChannelName(definitions[event]) ?? eventName
+    channels[channelName] = getChannel(eventName)
     return channels
-}
+}, {})
+
+module.exports = getChannels

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -1,5 +1,8 @@
 /**
  * Returns value of EventType Annotation if it is present. Otherwise it returns the definition name only.
+ * @param {string} eventName - The event definition name
+ * @param {object} eventDefinition - The event definition from CSN
+ * @return {string} The event type name
  */
 function getEventName(eventName, eventDefinition) {
 
@@ -14,25 +17,18 @@ function getEventName(eventName, eventDefinition) {
  * Returns value of ChannelName Annotation if it is present. Otherwise returns undefined.
  * This allows setting channel names independently from message/schema reference names,
  * enabling channel names with special characters like slashes.
+ * @param {object} eventDefinition - The event definition from CSN
+ * @return {string|undefined} The custom channel name or undefined if not specified
  */
-function getChannelName(eventName, eventDefinition) {
-
-    if (eventDefinition['@AsyncAPI.ChannelName']) {
-        return eventDefinition['@AsyncAPI.ChannelName']
-    }
-
-    return undefined
+function getChannelName(eventDefinition) {
+    return getOwnValue(eventDefinition, '@AsyncAPI.ChannelName')
 }
 
 /**
  * Gets the property value from the entry if it is defined otherwise returns undefined.
  */
 function getOwnValue(entry, key) {
-    if (Object.prototype.hasOwnProperty.call(entry, key)) {
-        return entry[key]
-    }
-
-    return
+    return Object.prototype.hasOwnProperty.call(entry, key) ? entry[key] : undefined
 }
 
 /**

--- a/lib/compile/utils.js
+++ b/lib/compile/utils.js
@@ -11,6 +11,20 @@ function getEventName(eventName, eventDefinition) {
 }
 
 /**
+ * Returns value of ChannelName Annotation if it is present. Otherwise returns undefined.
+ * This allows setting channel names independently from message/schema reference names,
+ * enabling channel names with special characters like slashes.
+ */
+function getChannelName(eventName, eventDefinition) {
+
+    if (eventDefinition['@AsyncAPI.ChannelName']) {
+        return eventDefinition['@AsyncAPI.ChannelName']
+    }
+
+    return undefined
+}
+
+/**
  * Gets the property value from the entry if it is defined otherwise returns undefined.
  */
 function getOwnValue(entry, key) {
@@ -60,6 +74,7 @@ function getDescription(definition, i18nBundle) {
 
 module.exports = {
     getEventName,
+    getChannelName,
     getOwnValue,
     resolveI18n,
     getDescription

--- a/test/lib/compile/asyncapiMetadata.test.js
+++ b/test/lib/compile/asyncapiMetadata.test.js
@@ -106,4 +106,26 @@ describe('asyncapi export: presets and annotations', () => {
         assert.ok(!('console' in generatedAsyncAPI))
         assert.ok(!generatedAsyncAPI.console)
     })
+
+    test('ChannelName annotation allows channel names with slashes', async () => {
+        const inputCDS = await read(join(baseInputPath, 'valid', 'channelName.cds'))
+        const csn = cds.compile.to.csn(inputCDS)
+        const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'channelName.json')))
+        const generatedAsyncAPI = toAsyncAPI(csn, { service: 'com.sap.channelname.StudyEventsService' })
+
+        // Verify channel name with slashes is used
+        assert.ok(generatedAsyncAPI.channels['default/sap.ctsm.study.prod/-/study/material'])
+
+        // Verify message reference does not contain slashes
+        assert.strictEqual(
+            generatedAsyncAPI.channels['default/sap.ctsm.study.prod/-/study/material'].subscribe.message.$ref,
+            '#/components/messages/study_material'
+        )
+
+        // Verify message key is safe for JSON pointers
+        assert.ok(generatedAsyncAPI.components.messages['study_material'])
+
+        // Full comparison
+        assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
+    })
 })

--- a/test/lib/compile/asyncapiMetadata.test.js
+++ b/test/lib/compile/asyncapiMetadata.test.js
@@ -112,20 +112,6 @@ describe('asyncapi export: presets and annotations', () => {
         const csn = cds.compile.to.csn(inputCDS)
         const expectedAsyncAPI = JSON.stringify(await read(join(baseOutputPath, 'channelName.json')))
         const generatedAsyncAPI = toAsyncAPI(csn, { service: 'com.sap.channelname.StudyEventsService' })
-
-        // Verify channel name with slashes is used
-        assert.ok(generatedAsyncAPI.channels['default/sap.ctsm.study.prod/-/study/material'])
-
-        // Verify message reference does not contain slashes
-        assert.strictEqual(
-            generatedAsyncAPI.channels['default/sap.ctsm.study.prod/-/study/material'].subscribe.message.$ref,
-            '#/components/messages/study_material'
-        )
-
-        // Verify message key is safe for JSON pointers
-        assert.ok(generatedAsyncAPI.components.messages['study_material'])
-
-        // Full comparison
         assert.deepStrictEqual(generatedAsyncAPI, JSON.parse(expectedAsyncAPI))
     })
 })

--- a/test/lib/compile/asyncapiOptions.test.js
+++ b/test/lib/compile/asyncapiOptions.test.js
@@ -72,7 +72,7 @@ describe('asyncapi export: options', () => {
     for (const [, metadata] of generatedAsyncAPI) {
       filesFound.add(metadata.file)
     }
-    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S']))
+    assert.deepStrictEqual(filesFound, new Set(['com.sap.bookstore.BookStore', 'com.sap.bookstore.AuthorService', 'com.sap.base.Base', 'com.sap.presets.S', 'com.sap.annotations.S', 'com.sap.channelname.StudyEventsService']))
   })
 
   test('Merged flag throws an error if title and version are not specified', async () => {

--- a/test/lib/compile/input/valid/channelName.cds
+++ b/test/lib/compile/input/valid/channelName.cds
@@ -1,0 +1,23 @@
+namespace com.sap.channelname;
+
+entity Study {
+  key id : UUID;
+  status : String;
+  material : String;
+};
+
+@AsyncAPI.Title        : 'Study Events Service'
+@AsyncAPI.SchemaVersion: '1.0.0'
+service StudyEventsService {
+  // Event with custom channel name containing slashes (legacy Event Mesh topic path)
+  @AsyncAPI.EventType   : 'study_material'
+  @AsyncAPI.ChannelName : 'default/sap.ctsm.study.prod/-/study/material'
+  event study_material : projection on Study;
+
+  // Event without custom channel name (uses EventType)
+  @AsyncAPI.EventType   : 'study.status.changed.v1'
+  event study_status : projection on Study;
+
+  // Event without any annotations (uses event name)
+  event study_created : projection on Study;
+}

--- a/test/lib/compile/output/channelName.json
+++ b/test/lib/compile/output/channelName.json
@@ -1,0 +1,305 @@
+{
+  "asyncapi": "2.0.0",
+  "x-sap-catalog-spec-version": "1.2",
+  "x-sap-application-namespace": "com.sap.test",
+  "info": {
+    "version": "1.0.0",
+    "title": "Study Events Service"
+  },
+  "defaultContentType": "application/json",
+  "channels": {
+    "default/sap.ctsm.study.prod/-/study/material": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/study_material"
+        }
+      }
+    },
+    "study.status.changed.v1": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/study.status.changed.v1"
+        }
+      }
+    },
+    "com.sap.channelname.StudyEventsService.study_created": {
+      "subscribe": {
+        "message": {
+          "$ref": "#/components/messages/com.sap.channelname.StudyEventsService.study_created"
+        }
+      }
+    }
+  },
+  "components": {
+    "messageTraits": {
+      "CloudEventsContext.v1": {
+        "headers": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Identifies the event.",
+              "type": "string",
+              "examples": [
+                "6925d08e-bc19-4ad7-902e-bd29721cc69b"
+              ]
+            },
+            "specversion": {
+              "description": "The version of the CloudEvents specification which the event uses.",
+              "type": "string",
+              "const": "1.0"
+            },
+            "source": {
+              "description": "Identifies the instance the event originated in.",
+              "type": "string",
+              "format": "uri-reference",
+              "examples": [
+                "/default/sap.s4.beh/ER9CLNT001",
+                "/eu/sap.billing.sb/91dec60d-9757-4e2c-b9e5-21da10016fe9"
+              ]
+            },
+            "type": {
+              "description": "Describes the type of the event related to the source the event originated in.",
+              "type": "string",
+              "examples": [
+                "sap.dsc.FreightOrder.Arrived.v1",
+                "sap.billing.sb.Subscription.Canceled.v1"
+              ]
+            },
+            "subject": {
+              "description": "Describes the subject of the event in the context of the source the event originated in (e.g., the id of the business object the event is about).",
+              "type": "string",
+              "examples": [
+                "ce307052-75a0-4a8f-a961-ebf21669bb80",
+                "urn:epc:tag:sgtin-96:1.7332402.026591.1234567890"
+              ]
+            },
+            "datacontenttype": {
+              "description": "Content type of the event data.",
+              "type": "string",
+              "const": "application/json"
+            },
+            "dataschema": {
+              "description": "Identifies the schema that the event data adheres to.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "http://example.com/event/sap.billing.sb.Subscription.Canceled/v1.2.0"
+              ]
+            },
+            "time": {
+              "description": "Timestamp of when the occurrence happened.",
+              "format": "date-time",
+              "type": "string",
+              "examples": [
+                "2018-04-05T17:31:00Z"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "source",
+            "specversion",
+            "type"
+          ],
+          "patternProperties": {
+            "^xsap[a-z0-9]+$": {
+              "description": "Application defined custom extension context attributes.",
+              "type": [
+                "boolean",
+                "integer",
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "messages": {
+      "study_material": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "study_material",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "study_material"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/study_material"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "study.status.changed.v1": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "study.status.changed.v1",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "study.status.changed.v1"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/study.status.changed.v1"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      },
+      "com.sap.channelname.StudyEventsService.study_created": {
+        "x-sap-event-source": "/{region}/{applicationNamespace}/{instanceId}",
+        "x-sap-event-source-parameters": {
+          "region": {
+            "description": "The regional context of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "applicationNamespace": {
+            "description": "The registered namespace of the application.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "instanceId": {
+            "description": "The instance id (tenant, installation, ...) of the application.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "name": "com.sap.channelname.StudyEventsService.study_created",
+        "headers": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "com.sap.channelname.StudyEventsService.study_created"
+            }
+          }
+        },
+        "payload": {
+          "$ref": "#/components/schemas/com.sap.channelname.StudyEventsService.study_created"
+        },
+        "traits": [
+          {
+            "$ref": "#/components/messageTraits/CloudEventsContext.v1"
+          }
+        ]
+      }
+    },
+    "schemas": {
+      "study_material": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": [
+              "e78f1eb8-ada8-49b0-8c8f-a5d316e82952"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "material": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "study.status.changed.v1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": [
+              "e78f1eb8-ada8-49b0-8c8f-a5d316e82952"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "material": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "com.sap.channelname.StudyEventsService.study_created": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": [
+              "e78f1eb8-ada8-49b0-8c8f-a5d316e82952"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "material": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #36 

# Introduce `@AsyncAPI.ChannelName` Annotation

### New Feature

✨ Introduces the `@AsyncAPI.ChannelName` annotation, enabling custom AsyncAPI channel names that are independent of message and schema reference names. This is particularly useful for legacy SAP Event Mesh topic paths containing slashes (e.g., `default/sap.ctsm.study.prod/-/study/material`), which were previously unsupported as channel keys.

Previously, the channel name was always derived from the event/message name. With this change, the channel key in the generated AsyncAPI spec can be freely set via `@AsyncAPI.ChannelName`, while message and schema `$ref` values continue to use the safe name from `@AsyncAPI.EventType` or the default event name.

### Changes

* `CHANGELOG.md`: Added entry documenting support for the new `@AsyncAPI.ChannelName` annotation.
* `lib/compile/channels.js`: Refactored channel generation to use `getChannelName()` for the channel key while keeping the event name for the message `$ref`, decoupling the two. Also converted imperative loop to a functional `reduce` style.
* `lib/compile/utils.js`: Added `getChannelName()` utility function that reads `@AsyncAPI.ChannelName` from an event definition. Also simplified `getOwnValue()` with a ternary expression, and exported `getChannelName`.
* `test/lib/compile/asyncapiMetadata.test.js`: Added a test verifying that `@AsyncAPI.ChannelName` produces a channel key with slashes while the message `$ref` remains a safe JSON pointer.
* `test/lib/compile/asyncapiOptions.test.js`: Updated the "service flag set to all" test to include the new `com.sap.channelname.StudyEventsService` in the expected output set.
* `test/lib/compile/input/valid/channelName.cds`: New CDS fixture defining a service with three events covering all resolution paths: custom channel name with `@AsyncAPI.ChannelName`, event type only via `@AsyncAPI.EventType`, and no annotations.
* `test/lib/compile/output/channelName.json`: New expected AsyncAPI output fixture demonstrating slash-based channel names alongside standard channel names, with message and schema references remaining unaffected.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.43`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `d9943caf-1f07-448f-a326-9af418a24f31`
- Event Trigger: `pull_request.edited`
</details>
