### PR TITLE
fix: Use enum values over their keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - Event descriptions now only appear in `components.messages.<event>.description` (removed from `components.schemas.<event>.description` to avoid duplication)
+- Enums values now take precedence over they respective keys in the output
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 
 - Event descriptions now only appear in `components.messages.<event>.description` (removed from `components.schemas.<event>.description` to avoid duplication)
-- Enums values now take precedence over they respective keys in the output
+- Enum values now take precedence over they respective keys in the output
 
 ## Version 1.0.3 - 12-03-2025
 

--- a/lib/compile/components/schemas/enum.js
+++ b/lib/compile/components/schemas/enum.js
@@ -2,7 +2,6 @@ const schemaUtils = require('./utils')
 
 function addEnum(entry, schema) {
     if (entry.kind === 'type') {
-        // eslint-disable-next-line no-unused-vars
         schema.enum = Object.entries(entry.enum).map(([key, value]) => {
             return (schemaUtils.isVal(value) ? value.val : key)
         })

--- a/lib/compile/components/schemas/enum.js
+++ b/lib/compile/components/schemas/enum.js
@@ -4,7 +4,7 @@ function addEnum(entry, schema) {
     if (entry.kind === 'type') {
         // eslint-disable-next-line no-unused-vars
         schema.enum = Object.entries(entry.enum).map(([key, value]) => {
-            return (schemaUtils.isVal(entry) ? entry.val : key)
+            return (schemaUtils.isVal(value) ? value.val : key)
         })
     } else {
         schema.enum = Object.keys(entry.enum)

--- a/test/lib/compile/components/schemas/input/enum.cds
+++ b/test/lib/compile/components/schemas/input/enum.cds
@@ -1,6 +1,6 @@
 namespace com.sap.test;
 
-type EnumType: String(10) enum { one = 'One'; two = 'Two'; };
+type EnumType: String(10) enum { one = 'ValueOne'; two = 'ValueTwo'; };
 
 @AsyncAPI.Title        : 'My Events'
 @AsyncAPI.SchemaVersion: '1.0.0'

--- a/test/lib/compile/components/schemas/output/enum.json
+++ b/test/lib/compile/components/schemas/output/enum.json
@@ -158,8 +158,8 @@
             "type": "string",
             "maxLength": 10,
             "enum": [
-              "one",
-              "two"
+              "ValueOne",
+              "ValueTwo"
             ]
           }
         }


### PR DESCRIPTION
Fixes internal issue 20584

# Fix: Use Enum Values Instead of Keys in Schema Generation

### Bug Fix

🐛 Fixed an incorrect enum schema generation where enum **keys** were being used instead of their corresponding **values** when building AsyncAPI schemas.

### Changes

* `lib/compile/components/schemas/enum.js`: Fixed a bug in the `addEnum` function where `entry` was being checked with `schemaUtils.isVal()` instead of the mapped `value`. The corrected logic now properly evaluates each enum entry's value and returns `value.val` when a value is present, falling back to the key otherwise.

* `test/lib/compile/components/schemas/input/enum.cds`: Updated the test CDS definition to use distinct enum values (`'ValueOne'`, `'ValueTwo'`) that differ from their keys (`one`, `two`), making the test more effective at catching this type of regression.

* `test/lib/compile/components/schemas/output/enum.json`: Updated the expected output to reflect that the generated schema should now correctly contain `"ValueOne"` and `"ValueTwo"` instead of the previously incorrect `"one"` and `"two"`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Correlation ID: `62b2b0c2-bfaf-463c-b9a8-f0975cba4d6f`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
