### PR TITLE
Introduce same release workflow as in other OSS repos

### DIFF
--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -1,0 +1,32 @@
+
+name: Prepare Next Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: Increment version
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+
+
+jobs:
+  prepare-next-version:
+    uses: cap-js/.github/.github/workflows/prepare-next-version.yml@main
+    secrets: inherit
+    with:
+      increment: ${{ github.event.inputs.increment }}

--- a/.github/workflows/prepare-next-version.yml
+++ b/.github/workflows/prepare-next-version.yml
@@ -19,7 +19,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
 name: Release
 
 on:
+  push:
+    branches: main
+
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+# Delegates to the shared release workflow in cap-js/.github
+# For more information see: https://github.com/cap-js/.github
+
+
 
 name: Release
 


### PR DESCRIPTION
# Introduce Standardized Release Workflow

### Chore

🔧 Aligns the release workflow of this repository with the pattern used across other OSS repos in the `cap-js` organization by introducing a shared `prepare-next-version` workflow and updating the `release.yml` trigger.

### Changes

* `.github/workflows/prepare-next-version.yml`: Added a new workflow that allows manually triggering a version bump (`patch`, `minor`, or `major`) by delegating to the shared reusable workflow at `cap-js/.github/.github/workflows/prepare-next-version.yml@main`.
* `.github/workflows/release.yml`: Added a `push` trigger on the `main` branch so that releases are automatically initiated when commits are pushed to `main`, in addition to the existing manual `workflow_dispatch` trigger. Also added a comment block referencing the GitHub Actions documentation.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `eba38e32-c0e2-49ac-aeb7-90cbf0923edc`
</details>
